### PR TITLE
Rewrite: run the installed script from disk instead of embedding it i…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Local research: DSM binaries (Synology proprietary — do not redistribute) and
+# config captures containing personal data. Kept locally, never committed.
+research/

--- a/README.md
+++ b/README.md
@@ -1,50 +1,109 @@
-# Synology DSM HDD hibernation fixer script
+# Synology DSM HDD hibernation fixer
 
-This script allows to fix multiple issues which prevent Synology NAS to have working HDD hibernation.
+Makes the hard drives of an x86 Synology NAS actually spin down (hibernate) by removing the
+things that keep waking them up. It is especially useful when you run Docker containers on an
+NVMe volume — by default DSM won't let HDDs hibernate while there is any NVMe activity.
 
-It is especially useful if you setup Docker containers on an NVMe partition - by default Synology NASes have a flaw which prevents HDD disks to hibernate when there is an ongoing NVMe activity.
+This is a cleaned-up rewrite of [AlexFromChaos/synology_hibernation_fixer](https://github.com/AlexFromChaos/synology_hibernation_fixer)
+(upstream, unmaintained since 2023). The fixes are based on the writeups
+[here](https://www.reddit.com/r/synology/comments/10cpbqd/making_disk_hibernation_work_on_synology_dsm_7/)
+and [here](https://www.reddit.com/r/synology/comments/129lzjg/fixing_hdd_hibernation_when_you_have_docker_on/).
 
-The script integrates changes I've described [here](https://www.reddit.com/r/synology/comments/10cpbqd/making_disk_hibernation_work_on_synology_dsm_7/) and [here](https://www.reddit.com/r/synology/comments/129lzjg/fixing_hdd_hibernation_when_you_have_docker_on/)
+Supported: **x86_64 NAS models on DSM 7.0 – 7.3** (verified against DSM 7.3.2).
 
-## Features
+## What it fixes
 
-- synocrond tasks control
-- interactive mode to specify what to do with synocrond tasks to adjust to your NAS usage scenario
-- applying in-memory patches for DSM binaries which prevent HDD hibernation to function normally when there is an NVMe activity (allows for eg. to setup noisy Docker containers on an NVMe partition and have working HDD hibernation)
-- automatic remounting of rootfs as `noatime` to avoid random wake ups
-- setting `noatime` for disk volumes
-- **persists after DSM upgrades**. No need to reapply the script after DSM updates (as long as Synology doesn't break something)
+Applied every time `--run` executes:
 
-The script should support all x86-based NAS models running DSM 7. Supported versions are 7.0, 7.1 and 7.2RC.
+1. **NVMe hibernation patch** — patches the *running* `scemd` and `synostgd-disk` processes in
+   memory so ongoing NVMe I/O no longer blocks HDD hibernation. Only process memory is changed,
+   never the on-disk binary, so this re-applies on each boot.
+2. **synocrond task tuning** — slows down or deletes the many built-in background jobs (disk
+   health, BTRFS maintenance, cert renewal, data collection, …) that wake disks. What to do with
+   each job is declared in a plain JSON config file — no more baking choices into the source.
+3. **noatime** — remounts `/` `noatime`, and (opt-in) sets data volumes to `noatime`.
+4. **synocached** — lowers the redis/synocached idle timeout from 3600 s to 900 s.
 
-Some of the fixes might be usable on DSM 6 as well, but I don't have a NAS with DSM 6 to test.
+## How it persists (what changed vs. the original)
 
-## How it works
+The original embedded the *entire script* as an `xz`+`base64` blob inside the Task Scheduler
+task. **This version does not.** Instead:
 
-Upon installation, the script creates a **Task Scheduler** task which is triggered to execute after a boot up. The task is self-contained - it has everything to execute within its body, so there is no need to keep the script `.py`-file anywhere on your NAS after installing.
+- `--install` copies the script to a data volume (default `/volume1/hiber_fixer/`) and writes a
+  config file next to it (`hiber_fixer.config.json`).
+- It creates a boot-up Task Scheduler task that simply runs
+  `python3 /volume1/hiber_fixer/hiber_fixer.py --run`.
 
-As this kind of scheduled tasks is preserved by DSM during a DSM upgrade, this approach allows to safely persist between DSM updates. Internally DSM keeps these tasks inside a database which has other user-added tasks.
+Both the task (kept in DSM's database) and the script (on a user volume) survive DSM upgrades.
 
-When invoked, the task verifies synocrond tasks configuration, changes their settings if necessary (like after a DSM update), applies other fixes and then exits - nothing left executing in the background.
-
-The script logs its execution in the `/var/log/hibernation_fixer.log` file.
+> **Note:** DSM updates sometimes *disable* root-privileged boot tasks. If your disks stop
+> hibernating after an update, run `--status`; if the task shows `DISABLED`, re-enable it in
+> **Control Panel → Task Scheduler**, or just re-run `--install`.
 
 ## Usage
 
-- login into your NAS via ssh
-- (optionally) switch to **root** via `sudo -i`
-- copy `hiber_fixer.py` (or just paste it via ssh) to any place on your NAS
-- run `sudo python3 hiber_fixer.py --install`
-- (optionally) reboot your NAS
-
-The script enumerates all synocrond tasks, prints their short descriptions and allows user to specify new triggering interval for every task (or delete them). The choices are saved inside the script before installing.
-
-### Uninstalling the script
-
-You can simply delete the **HDD Hibernation Fixer task** task in DSM's **Task Scheduler**.
-
-or, run
+SSH into your NAS and switch to root (`sudo -i`), then:
 
 ```bash
-sudo python3 hiber_fixer.py --uninstall
+# install (copies to /volume1/hiber_fixer, creates the boot task, applies fixes now)
+python3 hiber_fixer.py --install
+# or choose a different install location:
+python3 hiber_fixer.py --install --install-dir /volume2/hiber_fixer
+
+python3 hiber_fixer.py --run         # apply everything now (what the boot task runs)
+python3 hiber_fixer.py --status      # show current state (task, patch, noatime, config)
+python3 hiber_fixer.py --configure   # interactively edit which jobs to slow down / delete
+python3 hiber_fixer.py --diagnose    # dump patch-site info (use if a DSM update breaks the patch)
+python3 hiber_fixer.py --uninstall   # remove the boot task
 ```
+
+After `--install` you can delete the copy you ran it from; the active copy lives in the install
+directory. Logs go to `/var/log/hibernation_fixer.log`; backups of any modified config file go to
+`/var/synobackup`.
+
+## The config file
+
+`hiber_fixer.config.json` (created next to the script on install):
+
+```json
+{
+    "fixes": {
+        "nvme_in_memory_patch": true,
+        "remount_root_noatime": true,
+        "synocached_timeout_900": true,
+        "set_volumes_noatime": false
+    },
+    "synocrond_tasks": {
+        "builtin-synodatacollect-udc": "delete",
+        "builtin-libhwcontrol-disk_weekly_routine": "weekly",
+        "...": "..."
+    }
+}
+```
+
+Each task action is one of `unchanged | hourly | daily | weekly | monthly | delete`. Sensible
+defaults are filled in; edit and re-run `--run`. New tasks introduced by future DSM/package
+updates are added automatically (as `unchanged`) so you can review them. Setting
+`set_volumes_noatime` to `true` will change your data volumes to `noatime` (requires a reboot).
+
+## How the NVMe patch works (for the curious)
+
+Decompilation (Ghidra) shows both binaries call `SYNODiskPortEnum(portType, &list)` to build a
+list of disk ports, then decide hibernation from it:
+
+- `scemd` (`polling_hibernation_timer.c`) enumerates port types **1, 2** (internal SATA) and
+  **7** (NVMe), then `DiskListIdleEnough(list)` decides whether the HDDs may sleep.
+- `synostgd-disk` (`disk_monitor.c`) loops enumerating port types **1, 3, 7, 11** and watches
+  each disk for activity.
+
+**Port type 7 is NVMe**, so including it lets NVMe I/O keep the HDDs awake. The patch removes NVMe
+from those lists — in `scemd` by changing the argument (`7` → `0x0B`), in `synostoraged` by
+inserting a 2-byte `jmp` that skips the type-7 enumeration. The byte patterns are identical across
+DSM 7.2 and 7.3.2; if a future DSM recompiles these binaries and the patterns stop matching,
+`--run` logs a loud error and `--diagnose` dumps the candidate sites so new patterns can be
+generated (re-decompile with Ghidra to confirm the `SYNODiskPortEnum(7,…)` site).
+
+## Uninstalling
+
+Delete the **"HDD Hibernation Fixer task"** in **Task Scheduler**, or run
+`python3 hiber_fixer.py --uninstall`. Reboot to fully revert the in-memory patch.

--- a/hiber_fixer.py
+++ b/hiber_fixer.py
@@ -1,57 +1,108 @@
 #!/usr/bin/env python3
-import sys, os, fnmatch, shutil, platform, time
+# -*- coding: utf-8 -*-
+"""
+Synology DSM HDD hibernation fixer
+==================================
+
+Makes the hard drives of an x86 Synology NAS actually spin down (hibernate) by
+removing the things that keep waking them up. Tested target: DSM 7.0 - 7.3.
+
+What it does (all applied by ``--run``):
+
+  1. NVMe hibernation fix  -- patches the *running* ``scemd`` and ``synostgd-disk``
+     processes in memory so that ongoing NVMe I/O no longer blocks HDD
+     hibernation (the classic "Docker on an NVMe volume keeps my HDDs awake"
+     problem). Nothing on disk is modified, so this must run once per boot.
+  2. synocrond task tuning -- slows down or deletes the many built-in background
+     jobs (disk health, BTRFS maintenance, data collection, ...) that wake disks.
+     Which job does what is declared in an external JSON config file.
+  3. noatime           -- remounts ``/`` noatime and (optionally) sets data
+     volumes to noatime, to stop access-time writes from waking disks.
+  4. synocached        -- lowers the redis/synocached idle timeout 3600 -> 900s.
+
+How it persists
+---------------
+``--install`` copies this script to a data volume (default /volume1/hiber_fixer),
+writes a config file next to it, and creates a **boot-up Task Scheduler task that
+simply runs this script** (``python3 .../hiber_fixer.py --run``). No compressed
+copy of the script is embedded in the task. Both the task (kept in DSM's DB) and
+the script (on a user volume) survive DSM upgrades.
+
+Usage
+-----
+    sudo python3 hiber_fixer.py --install [--install-dir DIR]
+    sudo python3 hiber_fixer.py --run          # apply everything now (used by the task)
+    sudo python3 hiber_fixer.py --status        # show current state
+    sudo python3 hiber_fixer.py --configure     # interactively edit the config
+    sudo python3 hiber_fixer.py --diagnose      # dump patch-site info (for new DSM builds)
+    sudo python3 hiber_fixer.py --uninstall [--purge]
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import fnmatch
+import json
+import logging
+import os
+import platform
 import re
+import shutil
+import signal
 import struct
 import subprocess
-import signal
-import logging as log
-import json
-import lzma
-import base64
-from ctypes import *
-from collections import namedtuple
+import sys
+import time
+from ctypes import CDLL, POINTER, Structure, c_int, c_size_t, c_ssize_t, c_uint64, c_ulong, c_void_p, cast, create_string_buffer
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
 
-TASK_SCHEDULER_TASKNAME = "HDD Hibernation Fixer task"
+# --------------------------------------------------------------------------- #
+# Paths / constants
+# --------------------------------------------------------------------------- #
 
-LOGFILE = "/var/log/hibernation_fixer.log"
-LOGLEVEL = log.DEBUG
-
+TASK_NAME = "HDD Hibernation Fixer task"          # kept identical to the old script so --install replaces it
+DEFAULT_INSTALL_DIR = "/volume1/hiber_fixer"
+CONFIG_BASENAME = "hiber_fixer.config.json"
+LOG_PATH = "/var/log/hibernation_fixer.log"
 BACKUP_DIR = "/var/synobackup"
+
+PYTHON = "/usr/bin/python3"
+
 SCEMD_PATH = "/usr/syno/bin/scemd"
 SYNOSTORAGED_PATH = "/usr/syno/sbin/synostoraged"
-SYNOWEBAPI_PATH = "/usr/syno/bin/synowebapi"
 SYNOCROND_CONFIG_PATH = "/usr/syno/etc/synocrond.config"
 SPACE_TABLE_PATH = "/var/lib/space/space_table"
 VOLUME_CONF_PATH = "/usr/syno/etc/volume.conf"
 SYNOINFO_CONF_PATH = "/etc/synoinfo.conf"
-SYNOCACHED_CONF_DIRPATH = "/usr/syno/etc/synocached"
+SYNOCACHED_DIR = "/usr/syno/etc/synocached"
+VERSION_PATH = "/etc.defaults/VERSION"
+
+SYNOGETKEYVALUE = "/usr/syno/bin/synogetkeyvalue"
+SYNOSETKEYVALUE = "/usr/syno/bin/synosetkeyvalue"
+ESYNOSCHEDULER_CANDIDATES = ["/usr/syno/sbin/esynoscheduler", "/usr/syno/bin/esynoscheduler"]
+
+SYNOCROND_TASK_DIRS = [
+    "/usr/syno/share/synocron.d/",
+    "/usr/syno/etc/synocron.d/",
+    "/usr/local/etc/synocron.d/",
+]
+
+VALID_ACTIONS = ("unchanged", "hourly", "daily", "weekly", "monthly", "delete")
+PERIOD_ACTIONS = ("hourly", "daily", "weekly", "monthly")
+
+BOOT_WAIT_TIMEOUT = 180           # seconds to wait for the system to finish booting
+
+log = logging.getLogger("hiber_fixer")
 
 
-# patches is a list of tuples (orig_pattern, new_pattern, description)
-BinaryPatchSet = namedtuple("BinaryPatchSet",
-                            ["process_name", "binary_path", "patches"])
+# --------------------------------------------------------------------------- #
+# Recommended default action for each known synocrond task.
+# Unknown tasks (e.g. added by a future DSM/package) default to "unchanged".
+# --------------------------------------------------------------------------- #
 
-scemd_patchset = BinaryPatchSet("scemd", SCEMD_PATH, [
-    (b'\x48\x89\xDE\xBF\x01\x00\x00\x00\x48\x89\x04\\x24\xE8(....)\x48\x89\xDE\xBF\x02\x00\x00\x00\x89\xC5\xE8(....)\x48\x89\xDE\xBF\x07\x00\x00\x00\xE8(....)\x85\xED',
-     b'\x48\x89\xDE\xBF\x01\x00\x00\x00\x48\x89\x04\x24\xE8\g<01>\x48\x89\xDE\xBF\x02\x00\x00\x00\x89\xC5\xE8\g<02>\x48\x89\xDE\xBF\x0B\x00\x00\x00\xE8\g<03>\x85\xED',
-     "NVMe I/O HDD hibernation fix for DSM 7.0-7.1"),
-    (b'\x48\x89\xEE\xBF\x01\x00\x00\x00\x48\x89\x04\\x24\xE8(....)\x48\x89\xEE\xBF\x02\x00\x00\x00\x89\xC3\xE8(....)\x48\x89\xEE\xBF\x07\x00\x00\x00\xE8(....)\x85\xDB',
-     b'\x48\x89\xEE\xBF\x01\x00\x00\x00\x48\x89\x04\x24\xE8\g<01>\x48\x89\xEE\xBF\x02\x00\x00\x00\x89\xC3\xE8\g<02>\x48\x89\xEE\xBF\x0B\x00\x00\x00\xE8\g<03>\x85\xDB',
-     "NVMe I/O HDD hibernation fix for DSM 7.2"),
-    ])
-
-synostoraged_patchset = BinaryPatchSet("synostgd-disk", SYNOSTORAGED_PATH, [
-    (b'\x4C\x89\xEE\xBF\x03\x00\x00\x00\xE8(....)\x85\xC0\x0F\x88(....)\x4C\x89\xEE\xBF\x07\x00\x00\x00\xE8(....)\x85\xC0\x0F\x88(....)\x4C\x89\xEE\xBF\x0B\x00\x00\x00\xE8',
-     b'\x4C\x89\xEE\xBF\x03\x00\x00\x00\xE8\g<01>\x85\xC0\x0F\x88\g<02>\xEB\x13\xEE\xBF\x07\x00\x00\x00\xE8\g<03>\x85\xC0\x0F\x88\g<04>\x4C\x89\xEE\xBF\x0B\x00\x00\x00\xE8',
-     "NVMe I/O HDD hibernation fix for DSM 7.0-7.1"),
-    (b'\x48\x89\xDE\xBF\x03\x00\x00\x00\xE8(....)\x85\xC0\x0F\x88(....)\x48\x89\xDE\xBF\x07\x00\x00\x00\xE8(....)\x85\xC0\x0F\x88(....)\x48\x89\xDE\xBF\x0B\x00\x00\x00\xE8',
-     b'\x48\x89\xDE\xBF\x03\x00\x00\x00\xE8\g<01>\x85\xC0\x0F\x88\g<02>\xEB\x13\xDE\xBF\x07\x00\x00\x00\xE8\g<03>\x85\xC0\x0F\x88\g<04>\x48\x89\xDE\xBF\x0B\x00\x00\x00\xE8',
-     "NVMe I/O HDD hibernation fix for DSM 7.2"),
-    ])
-
-
-g_user_config = {
-    #BEGIN_CONFIG_SECTION
+DEFAULT_TASK_ACTIONS: Dict[str, str] = {
     "builtin-synodbud-synodbud": "delete",
     "builtin-dyn-synodbud-default": "delete",
     "builtin-dyn-autopkgupgrade-default": "delete",
@@ -77,16 +128,20 @@ g_user_config = {
     "builtin-syno_ntp_status_check-default": "monthly",
     "builtin-libsynostorage-syno_disk_db_update": "monthly",
     "builtin-libsynostorage-syno_btrfs_metadata_check": "monthly",
+    "builtin-libsynostorage-syno_disk_mail_send": "weekly",
     "pkg-ReplicationService-synobtrfsreplicacore-clean": "monthly",
     "builtin-Docker-docker_check_image_upgradable_job": "weekly",
     "pkg-Docker-docker_check_image_upgradable_job": "weekly",
     "pkg-Docker-default": "weekly",
     "builtin-ContainerManager-docker_check_image_upgradable_job": "weekly",
+    "pkg-ContainerManager-docker_check_image_upgradable_job": "weekly",
     "builtin-configautobackup-configautobackup": "unchanged",
     "builtin-dyn-configautobackup-default": "unchanged",
     "builtin-myds-job": "weekly",
     "builtin-dyn-myds-job": "weekly",
     "builtin-autopkgupgrade-autopkgupgrade": "weekly",
+    "builtin-synoupgrade_routine-default": "unchanged",
+    "builtin-dyn-syno-letsencrypt-syno-letsencrypt - renew": "unchanged",
     "builtin-Spreadsheet-auto_clean_weekly": "monthly",
     "builtin-Spreadsheet-auto_office_clean_temp_daily": "weekly",
     "builtin-SynologyDrive-caculate-db-usage": "weekly",
@@ -97,1074 +152,1271 @@ g_user_config = {
     "builtin-DownloadStation-DownloadStationUpdateJob": "monthly",
     "builtin-DownloadStation-DownloadStationMonitorTransmissionJob": "weekly",
     "pkg-SynologyApplicationService-auto_vacuum_daily": "weekly",
-    #END_CONFIG_SECTION
-    }
+    "pkg-SMBService-smb_stats_update_job": "weekly",
+    "pkg-SynoAnalytics-synoanalytics": "delete",
+    "pkg-WebStation-webstaion_job": "weekly",
+}
+
+DEFAULT_FIXES = {
+    "nvme_in_memory_patch": True,
+    "remount_root_noatime": True,
+    "synocached_timeout_900": True,
+    "set_volumes_noatime": False,   # requires a reboot; opt-in only
+}
+
+# Short descriptions shown by --status / --configure.
+TASK_DESCRIPTIONS: Dict[str, str] = {
+    "builtin-synodbud-synodbud": "updates misc DBs (abuser-blocklist, geoip, ca-certs, securityscan)",
+    "builtin-dyn-synodbud-default": "updates misc DBs (abuser-blocklist, geoip, ca-certs, securityscan)",
+    "builtin-dyn-autopkgupgrade-default": "update checker for installed packages",
+    "builtin-libhwcontrol-disk_daily_routine": "disk SMART info collector",
+    "builtin-libhwcontrol-disk_monthly_routine": "HDD performance-stats monitor",
+    "builtin-libhwcontrol-disk_weekly_routine": "checks SMART/hotspare status for disks",
+    "builtin-libhwcontrol-syno_disk_health_record": "parses disk_overview.xml (remaining life, errors, ...)",
+    "builtin-libsynostorage-syno_disk_health_record": "parses disk_overview.xml (remaining life, errors, ...)",
+    "builtin-synobtrfssnap-synobtrfssnap": "cleans up deleted BTRFS subvolumes",
+    "builtin-synobtrfssnap-synostgreclaim": "checks number of deleted BTRFS volumes to reclaim",
+    "builtin-synocrond_btrfs_free_space_analyze-default": "calculates BTRFS fragmentation per volume",
+    "builtin-synodatacollect-udc": "user data collection",
+    "builtin-synodatacollect-udc-disk": "user data collection (disk)",
+    "builtin-synorenewdefaultcert-renew_default_certificate": "manages cryptographic certificates",
+    "builtin-synorenewdefaultcert-default": "manages cryptographic certificates",
+    "builtin-synosharesnaptree_reconstruct-default": "reconstructs BTRFS snapshot tree",
+    "builtin-synosharing-default": "cleans up sharing.db SQLite tables",
+    "builtin-synolegalnotifier-synolegalnotifier": "downloads user agreements from Synology",
+    "builtin-synolegalnotifier-default": "downloads user agreements from Synology",
+    "builtin-syno_ew_weekly_check-extended_warranty_check": "queries Synology for extended-warranty info",
+    "builtin-syno_ew_weekly_check-default": "queries Synology for extended-warranty info",
+    "builtin-syno_ntp_status_check-check_ntp_status": "runs NTP time sync",
+    "builtin-syno_ntp_status_check-default": "runs NTP time sync",
+    "builtin-libsynostorage-syno_disk_db_update": "downloads/extracts disk compatibility DB",
+    "builtin-libsynostorage-syno_btrfs_metadata_check": "checks BTRFS metadata usage, emails alerts",
+    "builtin-libsynostorage-syno_disk_mail_send": "sends disk-related notification e-mails",
+    "pkg-ReplicationService-synobtrfsreplicacore-clean": "cleans up received BTRFS backup snapshots",
+    "builtin-Docker-docker_check_image_upgradable_job": "Docker upgradable-image checker",
+    "pkg-Docker-docker_check_image_upgradable_job": "Docker upgradable-image checker",
+    "pkg-ContainerManager-docker_check_image_upgradable_job": "Container Manager upgradable-image checker",
+    "builtin-synoupgrade_routine-default": "DSM upgrade routine",
+    "pkg-SMBService-smb_stats_update_job": "updates SMB usage statistics",
+    "pkg-SynoAnalytics-synoanalytics": "Synology analytics / data collection",
+    "pkg-WebStation-webstaion_job": "Web Station cron job",
+    "builtin-dyn-syno-letsencrypt-syno-letsencrypt - renew": "renews Let's Encrypt certificates",
+}
 
 
-_print_to_console = False
-
-def err(mes):
-    if _print_to_console:
-        print(f"ERROR: {mes}")
-    log.error(mes)
-
-def warn(mes):
-    if _print_to_console:
-        print(f"WARNING: {mes}")
-    log.warning(mes)
-
-def info(mes):
-    if _print_to_console:
-        print(f"INFO: {mes}")
-    log.warning(mes)
+def describe_task(name: str) -> str:
+    if name in TASK_DESCRIPTIONS:
+        return TASK_DESCRIPTIONS[name]
+    if name.startswith("pkg-"):
+        return "package-installed synocrond task"
+    return ""
 
 
-def get_pid_by_proc_name(process_name):
-    try:
-        return int(subprocess.check_output(["pidof", process_name]))
-    except:
-        return None
+# --------------------------------------------------------------------------- #
+# Small helpers
+# --------------------------------------------------------------------------- #
+
+def run_cmd(args: List[str], check: bool = False) -> subprocess.CompletedProcess:
+    """Run a command, capturing output as text. Never raises unless check=True."""
+    log.debug("exec: %s", " ".join(args))
+    return subprocess.run(args, capture_output=True, universal_newlines=True, check=check)
 
 
-ProcMapEntry = namedtuple("ProcMapEntry", ["start", "end", "perm", "offset", "dev", "inode", "pathname"])
-
-def parse_proc_maps(pid):
-    entries = []
-    maps_line_re = re.compile(r"(?P<start>[\da-f]+)-(?P<end>[\da-f]+)\s(?P<perm>\S+)\s(?P<offset>[\da-f]+)\s(?P<dev>\S+)\s+(?P<inode>\d+)\s+(?P<pathname>.*)$")
-
-    try:
-        with open(f"/proc/{pid}/maps", "r") as f:
-            for line in f.readlines():
-                m = maps_line_re.match(line)
-                if not m:
-                    log.debug(f"/proc/maps: skipping {line}")
-                    continue
-
-                start, end, perm, offset, dev, inode, pathname = m.groups()
-                entries.append(ProcMapEntry(
-                                start    = int(start, 16),
-                                end      = int(end,   16),
-                                perm     = perm,
-                                offset   = int(offset, 16),
-                                dev      = dev,
-                                inode    = inode,
-                                pathname = pathname.strip()))
-    except:
-        err(f"unable to access /proc/{pid}/maps")
-
-    return entries
-
-def get_module_base_addr(pid, module_name):
-    entries = parse_proc_maps(pid)
-    if not entries:
-        return None
-
-    filtered = [entry for entry in entries
-                      if os.path.basename(entry.pathname) == module_name]
-    if not filtered:
-        return None
-
-    for entry in filtered:
-        if entry.offset == 0:
-            return entry.start
-
-    warn(f"didn't find the module {module_name} base addr")
+def which_first(candidates: List[str]) -> Optional[str]:
+    for c in candidates:
+        if os.path.isfile(c) and os.access(c, os.X_OK):
+            return c
     return None
 
 
-# Returns a list of tuples (offset, orig_bytes, new_bytes)
-# or None on error
-def get_binary_patch_changelist(fpath, search_ptrn, replace_ptrn, max_matches=0):
-    changes = []    
+def backup_file(path: str) -> None:
+    """Back up a file into BACKUP_DIR before we modify it (best effort).
 
+    Backups are namespaced by full path (so same-named files in different dirs don't
+    collide) and the first/pristine copy is kept across re-runs."""
     try:
-        with open(fpath, "rb") as f:
-            data = f.read()
-    except:
-        err(f"cannot read {fpath}")
+        os.makedirs(BACKUP_DIR, exist_ok=True)
+        if not os.path.exists(path):
+            return
+        dest_name = path.replace(os.sep, "/").strip("/").replace("/", "_")
+        dest = os.path.join(BACKUP_DIR, dest_name)
+        if not os.path.exists(dest):
+            shutil.copy2(path, dest)
+    except Exception as e:
+        log.warning("could not back up %s: %s", path, e)
+
+
+def syno_get_key_value(conf_file: str, key: str) -> Optional[str]:
+    try:
+        out = subprocess.check_output([SYNOGETKEYVALUE, conf_file, key], universal_newlines=True)
+        return out.strip()
+    except Exception:
         return None
 
-    nmatches = len(re.findall(search_ptrn, data, flags=re.DOTALL))
-    if not nmatches:
-        return None
-    elif max_matches and nmatches > max_matches:
-        err("too many matches encountered")
-        return None
 
-    new_data = re.sub(search_ptrn, replace_ptrn, data, flags=re.DOTALL)
-    assert(len(new_data) == len(data))
+def syno_set_key_value(conf_file: str, key: str, value: str) -> bool:
+    try:
+        return subprocess.call([SYNOSETKEYVALUE, conf_file, key, value]) == 0
+    except Exception:
+        log.warning("failed to set %s=%s in %s", key, value, conf_file)
+        return False
 
-    new_bytes  = bytearray()
-    orig_bytes = bytearray()
-    changes_offset = 0
-    in_same = True
 
-    for i in range(len(data)):
-        if in_same:
-            if new_data[i] == data[i]:
-                continue
-            else:   # start of a new changed area
-                changes_offset = i
-                new_bytes  = [new_data[i]]
-                orig_bytes = [data[i]]
-                in_same = False
+def notify_user(title: str, message: str) -> None:
+    """Make a failure loud in the log. (No DSM popup: the notification templates
+    are fragile and firing the wrong one is worse than none. Users check via
+    --status / --diagnose.)"""
+    log.error("!!! %s: %s", title, message)
+
+
+# --------------------------------------------------------------------------- #
+# 1) In-memory binary patching (the NVMe hibernation fix)
+# --------------------------------------------------------------------------- #
+#
+# Each patch target is a running process plus a small set of "variants" (one per
+# DSM code layout). A variant is expressed as an ordered list of tokens so the
+# regex is built safely (literals are re.escape()d, avoiding the classic footgun
+# where a literal 0x24 byte becomes the regex metacharacter "$"):
+#
+#   search  token: bytes            -> literal bytes
+#                   ("any", n)       -> n wildcard bytes, captured in order
+#   replace token: bytes            -> literal bytes
+#                   ("cap", k)       -> reinsert the k-th captured group (1-based)
+#
+# Confirmed by Ghidra decompilation of the DSM 7.3.2 binaries:
+#   * scemd / polling_hibernation_timer.c -- the HDD-hibernation polling timer builds
+#     a disk list via SYNODiskPortEnum(portType, &list) for port types 1 and 2 (internal
+#     SATA) plus 7 (NVMe), then DiskListIdleEnough(list) decides whether the HDDs may sleep.
+#   * synostgd-disk / disk_monitor.c -- a forked monitor loop enumerates port types
+#     1, 3, 7 (NVMe) and 11 and watches each disk for activity.
+# Port type 7 == NVMe, so including it lets NVMe I/O keep the HDDs awake. The fix removes
+# NVMe from these lists:
+#   * scemd:        SYNODiskPortEnum(7,..) -> SYNODiskPortEnum(0x0B,..)   (byte 07 -> 0B)
+#   * synostoraged: insert a 2-byte jmp (EB 13) that skips the SYNODiskPortEnum(7,..) block
+# The byte sequences are unchanged from DSM 7.2 and verified to still match 7.3.2 exactly.
+
+Segment = object  # bytes | ("any", n) | ("cap", k)
+
+
+@dataclass
+class PatchVariant:
+    name: str
+    search: List[Segment]
+    replace: List[Segment]
+
+
+@dataclass
+class PatchTarget:
+    process_name: str
+    binary_path: str
+    variants: List[PatchVariant]
+
+
+def _compile_search(segments: List[Segment]) -> "re.Pattern":
+    rx = bytearray()
+    for s in segments:
+        if isinstance(s, (bytes, bytearray)):
+            rx += re.escape(bytes(s))
         else:
-            if new_data[i] != data[i]:  # changes continued
-                new_bytes.append(new_data[i])
-                orig_bytes.append(data[i])
-            else:   # end of changes
-                changes.append((changes_offset, bytes(orig_bytes), bytes(new_bytes)))
-                new_bytes = orig_bytes = []
-                in_same = True
-    if not in_same and new_bytes:
-        changes.append((changes_offset, bytes(orig_bytes), bytes(new_bytes)))
+            kind, n = s
+            assert kind == "any"
+            rx += b"(" + (b"." * n) + b")"
+    return re.compile(bytes(rx), re.DOTALL)
 
+
+def _build_replacement(segments: List[Segment], groups: Tuple[bytes, ...]) -> bytes:
+    out = bytearray()
+    for s in segments:
+        if isinstance(s, (bytes, bytearray)):
+            out += bytes(s)
+        else:
+            kind, k = s
+            assert kind == "cap"
+            out += groups[k - 1]
+    return bytes(out)
+
+
+# ---- the actual patch definitions ---------------------------------------- #
+
+SCEMD_TARGET = PatchTarget("scemd", SCEMD_PATH, [
+    PatchVariant(
+        "scemd DSM 7.2-7.3 (rbp)",
+        search=[b"\x48\x89\xEE\xBF\x01\x00\x00\x00\x48\x89\x04\x24\xE8", ("any", 4),
+                b"\x48\x89\xEE\xBF\x02\x00\x00\x00\x89\xC3\xE8", ("any", 4),
+                b"\x48\x89\xEE\xBF\x07\x00\x00\x00\xE8", ("any", 4),
+                b"\x85\xDB"],
+        replace=[b"\x48\x89\xEE\xBF\x01\x00\x00\x00\x48\x89\x04\x24\xE8", ("cap", 1),
+                 b"\x48\x89\xEE\xBF\x02\x00\x00\x00\x89\xC3\xE8", ("cap", 2),
+                 b"\x48\x89\xEE\xBF\x0B\x00\x00\x00\xE8", ("cap", 3),
+                 b"\x85\xDB"],
+    ),
+    PatchVariant(
+        "scemd DSM 7.0-7.1 (rbx)",
+        search=[b"\x48\x89\xDE\xBF\x01\x00\x00\x00\x48\x89\x04\x24\xE8", ("any", 4),
+                b"\x48\x89\xDE\xBF\x02\x00\x00\x00\x89\xC5\xE8", ("any", 4),
+                b"\x48\x89\xDE\xBF\x07\x00\x00\x00\xE8", ("any", 4),
+                b"\x85\xED"],
+        replace=[b"\x48\x89\xDE\xBF\x01\x00\x00\x00\x48\x89\x04\x24\xE8", ("cap", 1),
+                 b"\x48\x89\xDE\xBF\x02\x00\x00\x00\x89\xC5\xE8", ("cap", 2),
+                 b"\x48\x89\xDE\xBF\x0B\x00\x00\x00\xE8", ("cap", 3),
+                 b"\x85\xED"],
+    ),
+])
+
+SYNOSTORAGED_TARGET = PatchTarget("synostgd-disk", SYNOSTORAGED_PATH, [
+    PatchVariant(
+        "synostoraged DSM 7.2-7.3 (rbx)",
+        search=[b"\x48\x89\xDE\xBF\x03\x00\x00\x00\xE8", ("any", 4),
+                b"\x85\xC0\x0F\x88", ("any", 4),
+                b"\x48\x89\xDE\xBF\x07\x00\x00\x00\xE8", ("any", 4),
+                b"\x85\xC0\x0F\x88", ("any", 4),
+                b"\x48\x89\xDE\xBF\x0B\x00\x00\x00\xE8"],
+        replace=[b"\x48\x89\xDE\xBF\x03\x00\x00\x00\xE8", ("cap", 1),
+                 b"\x85\xC0\x0F\x88", ("cap", 2),
+                 b"\xEB\x13\xDE\xBF\x07\x00\x00\x00\xE8", ("cap", 3),   # 48 89 -> EB 13 (jmp over type-7 block)
+                 b"\x85\xC0\x0F\x88", ("cap", 4),
+                 b"\x48\x89\xDE\xBF\x0B\x00\x00\x00\xE8"],
+    ),
+    PatchVariant(
+        "synostoraged DSM 7.0-7.1 (r13)",
+        search=[b"\x4C\x89\xEE\xBF\x03\x00\x00\x00\xE8", ("any", 4),
+                b"\x85\xC0\x0F\x88", ("any", 4),
+                b"\x4C\x89\xEE\xBF\x07\x00\x00\x00\xE8", ("any", 4),
+                b"\x85\xC0\x0F\x88", ("any", 4),
+                b"\x4C\x89\xEE\xBF\x0B\x00\x00\x00\xE8"],
+        replace=[b"\x4C\x89\xEE\xBF\x03\x00\x00\x00\xE8", ("cap", 1),
+                 b"\x85\xC0\x0F\x88", ("cap", 2),
+                 b"\xEB\x13\xEE\xBF\x07\x00\x00\x00\xE8", ("cap", 3),   # 4C 89 -> EB 13
+                 b"\x85\xC0\x0F\x88", ("cap", 4),
+                 b"\x4C\x89\xEE\xBF\x0B\x00\x00\x00\xE8"],
+    ),
+])
+
+PATCH_TARGETS = [SCEMD_TARGET, SYNOSTORAGED_TARGET]
+
+
+# ---- ELF file-offset -> virtual-address mapping -------------------------- #
+
+@dataclass
+class ElfSegment:
+    offset: int
+    vaddr: int
+    filesz: int
+
+
+def parse_elf_load_segments(data: bytes) -> List[ElfSegment]:
+    if data[:4] != b"\x7fELF" or data[4] != 2:
+        raise ValueError("not an ELF64 file")
+    e_phoff = struct.unpack_from("<Q", data, 32)[0]
+    e_phentsize = struct.unpack_from("<H", data, 54)[0]
+    e_phnum = struct.unpack_from("<H", data, 56)[0]
+    segs: List[ElfSegment] = []
+    for i in range(e_phnum):
+        off = e_phoff + i * e_phentsize
+        p_type = struct.unpack_from("<I", data, off)[0]
+        if p_type == 1:  # PT_LOAD
+            p_offset, p_vaddr = struct.unpack_from("<QQ", data, off + 8)[0:2]
+            p_filesz = struct.unpack_from("<Q", data, off + 32)[0]
+            segs.append(ElfSegment(p_offset, p_vaddr, p_filesz))
+    return segs
+
+
+def file_offset_to_vaddr(segs: List[ElfSegment], foff: int) -> Optional[int]:
+    for s in segs:
+        if s.offset <= foff < s.offset + s.filesz:
+            return s.vaddr + (foff - s.offset)
+    return None
+
+
+# ---- compute the byte-level changelist for a binary ---------------------- #
+
+@dataclass
+class Change:
+    file_offset: int
+    orig: bytes
+    new: bytes
+
+
+def compute_changelist(binary_path: str, variant: PatchVariant) -> Optional[List[Change]]:
+    """Return the (file_offset, orig, new) changes for one matching variant, or
+    None if this variant's pattern does not occur exactly once."""
+    try:
+        with open(binary_path, "rb") as f:
+            data = f.read()
+    except OSError as e:
+        log.error("cannot read %s: %s", binary_path, e)
+        return None
+
+    rx = _compile_search(variant.search)
+    matches = list(rx.finditer(data))
+    if len(matches) != 1:
+        if len(matches) > 1:
+            log.error("variant '%s' matched %d times in %s (expected 1)", variant.name, len(matches), binary_path)
+        return None
+
+    m = matches[0]
+    new_block = _build_replacement(variant.replace, m.groups())
+    old_block = data[m.start():m.end()]
+    if len(new_block) != len(old_block):
+        log.error("variant '%s': replacement changed length (%d -> %d)", variant.name, len(old_block), len(new_block))
+        return None
+
+    changes: List[Change] = []
+    i = 0
+    n = len(old_block)
+    while i < n:
+        if old_block[i] != new_block[i]:
+            j = i
+            while j < n and old_block[j] != new_block[j]:
+                j += 1
+            changes.append(Change(m.start() + i, old_block[i:j], new_block[i:j]))
+            i = j
+        else:
+            i += 1
     return changes
 
 
-libc = None
+# ---- low-level process memory access ------------------------------------- #
 
 PTRACE_PEEKDATA = 2
 PTRACE_POKEDATA = 5
-PTRACE_ATTACH   = 16
-PTRACE_DETACH   = 17
+PTRACE_ATTACH = 16
+PTRACE_DETACH = 17
+
 
 class iovec(Structure):
-    _fields_ = [("iov_base", c_void_p),
-                ("iov_len",  c_size_t)]
-
-def init_ptrace():
-    global libc
-    libc = CDLL("libc.so.6")
-
-    libc.process_vm_readv.argtypes = [c_uint64, POINTER(iovec), c_ulong,
-                                      POINTER(iovec),  c_ulong, c_ulong]
-    libc.process_vm_readv.restype  = c_ssize_t
-
-    libc.process_vm_writev.argtypes = [c_uint64, POINTER(iovec), c_ulong,
-                                      POINTER(iovec),  c_ulong, c_ulong]
-    libc.process_vm_writev.restype  = c_ssize_t
-
-    libc.ptrace.argtypes = [c_uint64, c_uint64, c_void_p, c_void_p]
-    libc.ptrace.restype  = c_uint64
-
-    libc.__errno_location.restype = POINTER(c_int)
+    _fields_ = [("iov_base", c_void_p), ("iov_len", c_size_t)]
 
 
-# addrs_and_lens is a list of tuples (vaddr, num_bytes)
-# Returns: list of 'bytes' entries
-def read_mem_sg_list(pid, addrs_and_lens):
-    iovcnt = len(addrs_and_lens)
-    total_bytes = 0
+class _Libc:
+    def __init__(self) -> None:
+        self.libc = CDLL("libc.so.6", use_errno=True)
+        self.libc.process_vm_readv.argtypes = [c_uint64, POINTER(iovec), c_ulong, POINTER(iovec), c_ulong, c_ulong]
+        self.libc.process_vm_readv.restype = c_ssize_t
+        self.libc.ptrace.argtypes = [c_uint64, c_uint64, c_void_p, c_void_p]
+        self.libc.ptrace.restype = c_uint64
 
-    iovec_arr_type = iovec * iovcnt
+    def read_mem(self, pid: int, addr: int, length: int) -> Optional[bytes]:
+        buf = create_string_buffer(length)
+        local = iovec(cast(buf, c_void_p), length)
+        remote = iovec(c_void_p(addr), length)
+        ret = self.libc.process_vm_readv(pid, ctypes.byref(local), 1, ctypes.byref(remote), 1, 0)
+        if ret != length:
+            log.error("process_vm_readv(pid=%d, addr=%#x, len=%d) -> %d (%s)",
+                      pid, addr, length, ret, os.strerror(ctypes.get_errno()))
+            return None
+        return buf.raw
 
-    local_iov  = iovec_arr_type()
-    remote_iov = iovec_arr_type()
-
-    readbufs = []
-    for i, (vaddr, part_len) in enumerate(addrs_and_lens):
-        total_bytes += part_len
-        entry_buf = create_string_buffer(part_len)
-        readbufs.append(entry_buf)
-        remote_iov[i] = iovec(c_void_p(vaddr), part_len)
-        local_iov[i]  = iovec(cast(entry_buf, c_void_p), part_len)
-
-    ret = libc.process_vm_readv(pid, local_iov, iovcnt, remote_iov, iovcnt, 0)
-    if ret < 0:
-        err("failed to read remote process memory, errno() = "
-            f"{os.strerror(libc.__errno_location().contents.value)}")
-        return []
-    elif ret != total_bytes:
-        err("partial remote process memory reads are unsupported")
-        return []
-
-    return [buf.raw for buf in readbufs]
-
-
-# sg_list is a list of tuples (vaddr, bytes), process_vm_writev is a
-# useless shit (only allows writes to the heap)
-def write_mem_sg_list(pid, sg_list):
-    ret = libc.ptrace(PTRACE_ATTACH, pid, None, None)
-    if ret < 0:
-        err(f"ptrace attach failed for pid {pid}")
-        return False
-
-    _, status = os.waitpid(pid, 0)
-    if os.WIFSTOPPED(status):
-        stop_signal = os.WSTOPSIG(status)
-        if stop_signal != signal.SIGSTOP:
-            err(f"tracee stopped on unexpected signal {stop_signal}")
+    def write_mem(self, pid: int, writes: List[Tuple[int, bytes]]) -> bool:
+        """Write via ptrace POKEDATA (process_vm_writev cannot write RO code pages)."""
+        if self.libc.ptrace(PTRACE_ATTACH, pid, None, None) != 0:
+            log.error("ptrace ATTACH failed for pid %d", pid)
             return False
-    else:
-        err(f"ptrace stop failed for pid {pid}")
-        return False
-
-    result = True
-    for i, (vaddr, part_bytes) in enumerate(sg_list):
-        part_len = len(part_bytes)
-
-        for offset in range(0, part_len, 8):
-            val = libc.ptrace(PTRACE_PEEKDATA, pid, c_void_p(vaddr+offset), None)
-
-            if part_len - offset >= 8:
-                data = part_bytes[offset:offset+8]
-            else:
-                nbytes_left = part_len - offset
-                orig_bytes = struct.pack('<Q', val)
-                data = part_bytes[offset:offset+nbytes_left] + \
-                       orig_bytes[nbytes_left:]
-                            
-            val = struct.unpack("<Q", data)[0]
-
-            ret = libc.ptrace(PTRACE_POKEDATA, pid, c_void_p(vaddr+offset), c_void_p(val))
-            if ret < 0:
-                err(f"ptrace write mem failed for pid {pid},"
-                    "addr {:#x}, val {:#x}".format(vaddr+offset, val))
-                result = False
-                break
-
-    ret = libc.ptrace(PTRACE_DETACH, pid, None, None)
-    if ret < 0:
-        err(f"ptrace detach failed for pid {pid}")
-
-    return result
-
-
-def apply_in_memory_patches(pid, base_addr, changelist):
-    in_list = [(base_addr+offset, len(orig_bytes)) for offset, orig_bytes, _ in changelist]
-
-    out_list = read_mem_sg_list(pid, in_list)
-    if not out_list:
-        err(f"failed reading memory for pid {pid}")
-        return False
-
-    matched_original = True
-    matched_patched  = True
-    for i, entry in enumerate(out_list):
-        if matched_original and entry != changelist[i][1]:
-            matched_original = False
-
-        if matched_patched and entry != changelist[i][2]:
-            matched_patched = False
-
-    if matched_patched:
-        info(f"pid {pid} already has in-memory patches applied")
-        return True
-        
-    if not matched_original:
-        err(f"encountered memory content mismatch for pid {pid}")
-        return False
-
-    write_list = [(base_addr+offset, new_bytes) for offset, _, new_bytes in changelist]
-
-    log.debug(f"applying in-memory patches for pid {pid}")
-    return write_mem_sg_list(pid, write_list)
-
-
-def apply_binary_patchset(patchset):
-    proc_name = patchset.process_name
-    mod_fname = os.path.basename(patchset.binary_path)
-
-    pid = get_pid_by_proc_name(proc_name)
-    if not pid:
-        err(f"cannot find pid of {proc_name} process")
-        return False
-
-    image_base = get_module_base_addr(pid, mod_fname)
-    if not image_base:
-        err(f"cannot find {mod_fname} image base")
-        return False
-
-    matched_any = False
-    all_success = True
-    for orig_pattern, new_pattern, patch_descr in patchset.patches:
-        changelist = get_binary_patch_changelist(patchset.binary_path,
-                                                 orig_pattern,
-                                                 new_pattern,
-                                                 max_matches=1)
-        if changelist:
-            matched_any = True
-
-            rc = apply_in_memory_patches(pid, image_base, changelist)
-            if not rc:
-                all_success = False
-                err(f"failed to apply patch '{patch_descr}' for {proc_name}")
-            else:
-                log.debug(f"successfully applied patch '{patch_descr}' for {proc_name}")
-
-    return matched_any and all_success
-
-
-def do_in_memory_fixes():
-    init_ptrace()
-
-    # allow HDD hibernation when there is an ongoing NVMe activity
-    apply_binary_patchset(scemd_patchset)
-    apply_binary_patchset(synostoraged_patchset)
-
-
-def find_files_by_mask(pattern, path):
-    result = []
-
-    for root, dirs, files in os.walk(path):
-        for name in files:
-            if fnmatch.fnmatch(name, pattern):
-                result.append(os.path.join(root, name))
-
-    return result
-
-
-def enumerate_synocrond_task_files():
-    task_paths  = find_files_by_mask("*.conf", "/usr/syno/share/synocron.d/")
-    task_paths += find_files_by_mask("*.conf", "/usr/syno/etc/synocron.d/")
-    task_paths += find_files_by_mask("*.conf", "/usr/local/etc/synocron.d/")
-
-    #log.debug(f"found {len(task_paths)} synocrond task files")
-    return task_paths
-
-
-
-SynocrondTask = namedtuple("SynocrondTask", ["task_name", "body"])
-
-# Returns a dict {"fpath" -> [SynocrondTask, ...]}
-def load_synocrond_task_files(task_paths):
-    all_tasks = {}
-
-    # loads jsons, resolves task name if there is no 'name' field
-    # takes into account list/dict (creates multiple entries)
-    for taskpath in task_paths:
         try:
-            all_tasks[taskpath] = []
+            _, status = os.waitpid(pid, 0)
+            if not (os.WIFSTOPPED(status) and os.WSTOPSIG(status) == signal.SIGSTOP):
+                log.error("unexpected stop status %#x for pid %d", status, pid)
+                return False
 
-            with open(taskpath) as f:
-                obj = json.load(f)
+            ok = True
+            for addr, payload in writes:
+                for off in range(0, len(payload), 8):
+                    word_addr = addr + off
+                    chunk = payload[off:off + 8]
+                    if len(chunk) < 8:  # need the surrounding bytes to preserve the rest of the word
+                        ctypes.set_errno(0)
+                        old = self.libc.ptrace(PTRACE_PEEKDATA, pid, c_void_p(word_addr), None)
+                        eno = ctypes.get_errno()
+                        if eno != 0:
+                            log.error("ptrace PEEKDATA failed at %#x (pid %d): %s", word_addr, pid, os.strerror(eno))
+                            ok = False
+                            break
+                        chunk = chunk + struct.pack("<Q", old)[len(chunk):]
+                    val = struct.unpack("<Q", chunk)[0]
+                    if self.libc.ptrace(PTRACE_POKEDATA, pid, c_void_p(word_addr), c_void_p(val)) != 0:
+                        log.error("ptrace POKEDATA failed at %#x (pid %d)", word_addr, pid)
+                        ok = False
+                        break
+                if not ok:
+                    break
+            return ok
+        finally:
+            self.libc.ptrace(PTRACE_DETACH, pid, None, None)
 
-            if isinstance(obj, dict):
-                file_tasks = [obj]
-            elif isinstance(obj, list):
-                file_tasks = obj
-            else:
-                err(f"unknown JSON format while parsing the task file {taskpath}")
-                continue
 
-            fname = os.path.basename(taskpath)
-            if '.' in fname:
-                fname = fname.split('.')[0]
+def get_pid_by_name(name: str) -> Optional[int]:
+    try:
+        return int(subprocess.check_output(["pidof", name]).split()[0])
+    except Exception:
+        return None
 
-            for task in file_tasks:
-                if "name" in task:
-                    task_name = "builtin-" + fname + '-' + task["name"]
-                else:
-                    task_name = "builtin-" + fname + "-default"
 
-                all_tasks[taskpath].append(SynocrondTask(task_name, task))
+def get_module_base(pid: int, module_name: str) -> Optional[int]:
+    """Load bias of the module: the vaddr at which file offset 0 is mapped."""
+    line_re = re.compile(r"^([\da-f]+)-([\da-f]+)\s+\S+\s+([\da-f]+)\s+\S+\s+\d+\s+(.*)$")
+    try:
+        with open(f"/proc/{pid}/maps") as f:
+            for line in f:
+                m = line_re.match(line.rstrip("\n"))
+                if not m:
+                    continue
+                start, _end, offset, path = m.groups()
+                if os.path.basename(path.strip()) == module_name and int(offset, 16) == 0:
+                    return int(start, 16)
+    except OSError as e:
+        log.error("cannot read /proc/%d/maps: %s", pid, e)
+    return None
 
-        except Exception as e:
-            err(f"got exception {e} while parsing the task file {taskpath}")
+
+@dataclass
+class PatchOutcome:
+    target: str
+    matched_variant: Optional[str] = None
+    applied: bool = False
+    already_patched: bool = False
+    error: Optional[str] = None
+
+
+def apply_target(libc: _Libc, target: PatchTarget) -> PatchOutcome:
+    out = PatchOutcome(target=target.process_name)
+
+    pid = get_pid_by_name(target.process_name)
+    if not pid:
+        out.error = f"process '{target.process_name}' not running"
+        log.error(out.error)
+        return out
+
+    module = os.path.basename(target.binary_path)
+    base = get_module_base(pid, module)
+    if base is None:
+        out.error = f"could not find module base of {module} in pid {pid}"
+        log.error(out.error)
+        return out
+
+    try:
+        segs = parse_elf_load_segments(open(target.binary_path, "rb").read())
+    except Exception as e:
+        out.error = f"cannot parse ELF {target.binary_path}: {e}"
+        log.error(out.error)
+        return out
+
+    for variant in target.variants:
+        changes = compute_changelist(target.binary_path, variant)
+        if not changes:
             continue
+        out.matched_variant = variant.name
 
-    return all_tasks
+        # Resolve each change's file offset to a runtime address.
+        reads: List[Tuple[int, int]] = []
+        for ch in changes:
+            vaddr = file_offset_to_vaddr(segs, ch.file_offset)
+            if vaddr is None:
+                out.error = f"file offset {ch.file_offset:#x} not in any PT_LOAD segment"
+                log.error(out.error)
+                return out
+            reads.append((base + vaddr, len(ch.orig)))
 
-def load_synocrond_config():
+        current = [libc.read_mem(pid, addr, ln) for addr, ln in reads]
+        if any(c is None for c in current):
+            out.error = "failed reading target process memory"
+            return out
+
+        if all(current[i] == changes[i].new for i in range(len(changes))):
+            out.already_patched = True
+            log.info("%s: already patched in memory (%s)", target.process_name, variant.name)
+            return out
+
+        if not all(current[i] == changes[i].orig for i in range(len(changes))):
+            out.error = "memory content does not match expected original bytes"
+            log.error("%s: %s", target.process_name, out.error)
+            return out
+
+        writes = [(reads[i][0], changes[i].new) for i in range(len(changes))]
+        if libc.write_mem(pid, writes):
+            out.applied = True
+            log.info("%s: applied in-memory patch (%s)", target.process_name, variant.name)
+        else:
+            out.error = "ptrace write failed"
+        return out
+
+    out.error = "no known patch pattern matched the current binary"
+    log.error("%s: %s (%s) -- DSM may have changed this binary; run --diagnose",
+              target.process_name, out.error, target.binary_path)
+    return out
+
+
+def do_in_memory_fixes() -> bool:
+    try:
+        libc = _Libc()
+    except Exception as e:
+        log.error("failed to initialise libc bindings: %s", e)
+        return False
+
+    all_ok = True
+    unmatched = []
+    for target in PATCH_TARGETS:
+        outcome = apply_target(libc, target)
+        if outcome.error and not outcome.already_patched:
+            all_ok = False
+            if outcome.matched_variant is None:
+                unmatched.append(target.binary_path)
+
+    if unmatched:
+        notify_user("HDD Hibernation Fixer",
+                    "The NVMe hibernation patch no longer matches these DSM binaries: "
+                    + ", ".join(unmatched) + ". Run 'hiber_fixer.py --diagnose'.")
+    return all_ok
+
+
+# --------------------------------------------------------------------------- #
+# 2) synocrond task tuning
+# --------------------------------------------------------------------------- #
+
+@dataclass
+class SynocrondTask:
+    name: str
+    body: dict
+
+
+def _find_conf_files(directory: str) -> List[str]:
+    result = []
+    if not os.path.isdir(directory):
+        return result
+    for root, _dirs, files in os.walk(directory):
+        for name in files:
+            if fnmatch.fnmatch(name, "*.conf"):
+                result.append(os.path.join(root, name))
+    return result
+
+
+def enumerate_task_files() -> List[str]:
+    paths: List[str] = []
+    for d in SYNOCROND_TASK_DIRS:
+        paths += _find_conf_files(d)
+    return paths
+
+
+def load_task_file(path: str) -> List[SynocrondTask]:
+    """Parse one synocron.d .conf file into a list of tasks (files hold a dict or a list)."""
+    with open(path) as f:
+        obj = json.load(f)
+    entries = obj if isinstance(obj, list) else [obj]
+
+    fname = os.path.basename(path)
+    if "." in fname:
+        fname = fname.split(".")[0]
+
+    # Package tasks (under /usr/local/etc/synocron.d) are named pkg-<file>-<name> at
+    # runtime; built-in ones (share/ and etc/) use the builtin- prefix.
+    norm = path.replace(os.sep, "/")
+    prefix = "pkg-" if "/usr/local/etc/synocron.d/" in norm else "builtin-"
+
+    tasks = []
+    for entry in entries:
+        if "name" in entry:
+            name = prefix + fname + "-" + entry["name"]
+        else:
+            name = prefix + fname + "-default"
+        tasks.append(SynocrondTask(name, entry))
+    return tasks
+
+
+def task_period(body: dict) -> str:
+    period = body.get("period", "?")
+    if period == "crontab" and "crontab" in body:
+        period += f" ({body['crontab']})"
+    return period
+
+
+def clean_job_name(job_name: str) -> str:
+    # DSM 7.2+ prefixes runtime job keys with "synocrond-job-".
+    prefix = "synocrond-job-"
+    return job_name[len(prefix):] if job_name.startswith(prefix) else job_name
+
+
+def load_synocrond_config() -> Optional[dict]:
     try:
         with open(SYNOCROND_CONFIG_PATH) as f:
             return json.load(f)
-    except:
-        return None
-
-def save_synocrond_config(synocrond_config):
-    try:
-        shutil.copy(SYNOCROND_CONFIG_PATH, BACKUP_DIR)
-
-        with open(SYNOCROND_CONFIG_PATH, "w") as f:
-            json.dump(synocrond_config, f, indent=4)
-            return True
-    except:
-        return False
-
-
-def syno_get_key_value(conf_file, key):
-    try:
-        ret = subprocess.check_output(["/usr/syno/bin/synogetkeyvalue",
-                                       conf_file, key],
-                                       universal_newlines=True)
-        return ret.strip()
-    except:
-        return None
-
-def syno_set_key_value(conf_file, key, value):
-    try:
-        ret = subprocess.call(["/usr/syno/bin/synosetkeyvalue",
-                              conf_file, key, value])
-        return ret
-    except:
-        warn(f"failed to set {key}={value} in {conf_file}")
+    except Exception as e:
+        log.error("cannot load %s: %s", SYNOCROND_CONFIG_PATH, e)
         return None
 
 
-def remount_root_norelatime():
-    need_remount = True
-    try:
-        ret = subprocess.check_output(["mount"], universal_newlines=True)
-        lines = ret.split('\n')
-        for line in lines:
-            if "md0 on / " in line and "noatime" in line:
-                need_remount = False
-                break
-    except:
-        pass
+def discover_tasks() -> Dict[str, Tuple[str, str]]:
+    """Return {task_name: (current_period, description)} across task files and the live config."""
+    result: Dict[str, Tuple[str, str]] = {}
+    for path in enumerate_task_files():
+        try:
+            for t in load_task_file(path):
+                result[t.name] = (task_period(t.body), describe_task(t.name))
+        except Exception as e:
+            log.warning("skipping task file %s: %s", path, e)
 
-    if not need_remount:
-        return
-
-    try:
-        ret = subprocess.call(["mount", "-o", "noatime,remount", "/"],
-                              stdout=subprocess.DEVNULL,
-                              stderr=subprocess.DEVNULL)
-    except:
-        ret = 1
-
-    if ret:
-        err("remounting md0 failed, expect a lot of HDD wakeups due to relatime")
-
-
-
-
-def list_synoscheduler_tasks():
-    try:
-        out = subprocess.check_output([SYNOWEBAPI_PATH,
-                                       "--exec", "api=SYNO.Core.TaskScheduler",
-                                       "method=list",
-                                       "version=2"],
-                                       stderr=subprocess.DEVNULL)
-        print(f"Regular Task Scheduler tasks:\n{out.decode()}")
-
-        out = subprocess.check_output(["esynoscheduler", "--list"],
-                                       stderr=subprocess.DEVNULL)
-        print(f"Event-based Task Scheduler tasks:\n{out.decode()}")
-
-    except:
-        print("ERROR: failed to enumerate Task Scheduler tasks")
-
-
-def add_esynoscheduler_task(task_name, event_type, description, operation):
-    try:
-        args = ["esynoscheduler", "--create", f'task_name={task_name}',
-                f"event={event_type}", "enable=true", "operation_type=script",
-                f"operation={operation}"]
-
-        if description:
-            args.append(f"description={description}")
-
-        args.append(r'owner={"0":"root"}')  # uid:name
-
-        # other optionals:
-        #  - depend_on_task=s
-        #  - notify_enable=b
-        #  - notify_mail=b
-        #  - notify_if_error=b
-        #  - extra=s
-        ret = subprocess.check_output(args, stderr=subprocess.DEVNULL).decode()
-    except:
-        err(f"failed to create Task Scheduler task '{task_name}'")
-        return False
-
-    return True if "save ok" in ret else False
-
-def remove_esynoscheduler_task(task_name):
-    try:
-        ret = subprocess.check_output(["esynoscheduler", "--delete",
-                                       f'task_name={task_name}'],
-                                      stderr=subprocess.DEVNULL).decode()
-    except:
-        err(f"failed to delete Task Scheduler task '{task_name}'")
-        return False
-
-    return True if "delete task ok" in ret else False
-
-
-UDC_DESC = "user data collection related"
-SYNODBUD_DESC = "updates misc DBs: syno-abuser-blocklist, geoip-database, ca-certificates, securityscan-database"
-SYNO_DISK_HEALTH_RECORD_DESC = "parses /var/log/disk_overview.xml which has disk-related stats like remaining life, errors and other information"
-EW_WEEKLY_CHECK_DESC = "queries synology website for 'extended warranty' info, using device information, updates /var/cache/ew_info_cache.json"
-SYNOLEGALNOTIFIER_DESC = "'legal data downloader'. Downloads user agreements from Synology site, can notify user about them"
-NTP_STATUS_CHECK_DESC = "runs NTP time sync"
-RENEW_DEFAULT_CERTIFICATE_DESC = "processes cryptographic certificates - generates some, checks expiration, deletes, copies"
-DOCKER_CHECK_IMAGE_UPGRADABLE_DESC = "Docker upgradable image checker tool"
-
-known_task_descriptions = {
-    "builtin-synodbud-synodbud": SYNODBUD_DESC,  # /usr/syno/etc/synocron.d/synodbud.conf
-    "builtin-dyn-synodbud-default": SYNODBUD_DESC,
-    "builtin-dyn-autopkgupgrade-default": "update checker for installed packages",
-    "builtin-libhwcontrol-disk_daily_routine": "disk SMART info collector, updates info in /var/log/diskprediction/",
-    "builtin-libhwcontrol-disk_monthly_routine": "runs syno_disk_performance_monitor which works with HDD performance stats data in /var/log/disk-latency/",
-    "builtin-libhwcontrol-disk_weekly_routine": "checks SMART/hotspare status for disks, updates information in /var/log/smart_result/, adds data to /var/log/disk-latency/.SYNODISKLATENCYDB",
-    "builtin-libhwcontrol-syno_disk_health_record": SYNO_DISK_HEALTH_RECORD_DESC,
-    "builtin-libsynostorage-syno_disk_health_record": SYNO_DISK_HEALTH_RECORD_DESC,
-    "builtin-synobtrfssnap-synobtrfssnap": "cleans up all deleted subovlumes in the system",
-    "builtin-synobtrfssnap-synostgreclaim": "checks the number of deleted BTRFS volumes which need reclaiming",
-    "builtin-synocrond_btrfs_free_space_analyze-default": "calculates BTRFS fragmentation level for disks and writes results to a per-volume file 'frag_analysis'",
-    "builtin-synodatacollect-udc": UDC_DESC,
-    "builtin-synodatacollect-udc-disk": UDC_DESC,
-    "builtin-synorenewdefaultcert-renew_default_certificate": RENEW_DEFAULT_CERTIFICATE_DESC,
-    "builtin-synorenewdefaultcert-default": RENEW_DEFAULT_CERTIFICATE_DESC,
-    "builtin-synosharesnaptree_reconstruct-default": "runs /usr/syno/sbin/synosharesnaptree -x <volume>, which reconstructs BTRFS snapshot tree",
-    "builtin-synosharing-default": "does cleanup of SQLite DB tables (session/token/entry) in /usr/syno/etc/private/session/sharing/sharing.db",
-    "builtin-synolegalnotifier-synolegalnotifier": SYNOLEGALNOTIFIER_DESC,
-    "builtin-synolegalnotifier-default": SYNOLEGALNOTIFIER_DESC,
-    "builtin-syno_ew_weekly_check-extended_warranty_check": EW_WEEKLY_CHECK_DESC,
-    "builtin-syno_ew_weekly_check-default": EW_WEEKLY_CHECK_DESC,
-    "builtin-syno_ntp_status_check-check_ntp_status": NTP_STATUS_CHECK_DESC,
-    "builtin-syno_ntp_status_check-default": NTP_STATUS_CHECK_DESC,
-    "builtin-libsynostorage-syno_disk_db_update": "downloads the archive with Synology disk compatibility database and extracts it",
-    "builtin-libsynostorage-syno_btrfs_metadata_check": "checks BTRFS metadata usage and sends email notifications regarding it",
-    "pkg-ReplicationService-synobtrfsreplicacore-clean": "cleanups 'received' BTRFS backup snapshots",
-    "builtin-Docker-docker_check_image_upgradable_job": DOCKER_CHECK_IMAGE_UPGRADABLE_DESC,
-    "pkg-Docker-docker_check_image_upgradable_job": DOCKER_CHECK_IMAGE_UPGRADABLE_DESC,
-}
-
-def get_synocrond_task_description(taskname):
-    if taskname in known_task_descriptions:
-        return known_task_descriptions[taskname]
-
-    if taskname.startswith("pkg-"):
-        return "package-installed synocrond task"
-
-    return ""   # unknown
-
-
-def get_task_period(task_config):
-    period = task_config["period"]
-
-    if period == "crontab" and "crontab" in task_config:
-        crontab = task_config["crontab"]
-        period += f" ({crontab})"
-
-    return period
-
-def get_task_recommended_action(task_name):
-    if task_name in g_user_config:
-        return g_user_config[task_name]
-
-    log.debug(f"Encountered unfamiliar task {task_name}, suggesting to leave it unchanged")
-    return "unchanged"
-
-# Returns a dictionary of tuples
-# "task name": (current_period, description, default_option)
-def get_task_list_for_install():
-    result = {}
-    all_files_tasks = {}
-
-    task_files_paths = enumerate_synocrond_task_files()
-    if task_files_paths:
-        all_files_tasks = load_synocrond_task_files(task_files_paths)
-
-    for tasks in all_files_tasks.values():
-        for synotask in tasks:
-            task_name = synotask.task_name
-            descr = get_synocrond_task_description(task_name)
-            cur_period = get_task_period(synotask.body)
-            recommended_opt = get_task_recommended_action(task_name)
-            result[task_name] = (cur_period, descr, recommended_opt)
-
-    synocrond_config = load_synocrond_config()
-    if not synocrond_config:
-        err("(install) cannot load synocrond.config")
-        return result
-
-    jobs = synocrond_config["jobs"]
-
-    for task_name in jobs.keys():
-        # DSM 7.2 task naming change
-        clean_task_name = task_name
-        if task_name.find("synocrond-job-") == 0:
-            clean_task_name = task_name.replace("synocrond-job-", "")
-
-        descr = get_synocrond_task_description(clean_task_name)
-        cur_period = get_task_period(jobs[task_name]["config"])
-        recommended_opt = get_task_recommended_action(clean_task_name)
-        result[clean_task_name] = (cur_period, descr, recommended_opt)
-
+    cfg = load_synocrond_config()
+    if cfg:
+        for job_name, job in cfg.get("jobs", {}).items():
+            name = clean_job_name(job_name)
+            result[name] = (task_period(job.get("config", {})), describe_task(name))
     return result
 
 
-# ask user for choices, fill g_user_config
-def generate_user_config():
-    global g_user_config
-
-    tasks = get_task_list_for_install()
-
-    import textwrap
-    prompt = ("Select desired triggering periods for synocrond tasks. Depending "
-              "on your NAS usage scenario you might want to leave some of them "
-              "enabled (for eg. periodic BTRFS-related maintaining jobs). If you "
-              "don't want to specify your setup, you can just press Enter for all "
-              "tasks to choose the default recommended values")
-    prompt_wrap = "\n".join(textwrap.wrap(prompt, width=100))
-
-    try:
-        print("-" * 100)
-        print(prompt_wrap)
-        print("-" * 100)
-        input("Press Enter to start")
-        ntasks = len(tasks.keys())
-
-        for i, taskname in enumerate(tasks.keys()):
-            cur_period, descr, default_option = tasks[taskname]
-
-            while True:
-                print("\nTask {:02}/{:02}: {}".format(i+1, ntasks, taskname))
-                if descr:
-                    print(f"Description: {descr}")
-                print(f"Current triggering interval: {cur_period}")
-                print("New triggering interval, (u)nchanged, (w)eekly, (m)onthly, "
-                      f"(d)elete (default - {default_option}): ", end='')
-                ch = input()
-
-                if not ch:
-                    ch = default_option
-
-                selected = ""
-                if ch[0] == 'u':
-                    selected = "skip"
-                elif ch[0] == 'w':
-                    selected = "weekly"
-                elif ch[0] == 'm':
-                    selected = "monthly"
-                elif ch[0] == 'd':
-                    selected = "delete"
-                else:
-                    print("\nWrong input, please retry")
-                    continue
-
-                g_user_config[taskname] = selected
-                break
-
-    except KeyboardInterrupt:
-        print("\n\nCancelled")
-        return False
-    except:
-        print("\n\nBad input")
-        return False
-
-    return True
+def _handle_dyn_task_deletion(name: str) -> None:
+    """Extra work required to keep certain 'dynamic' tasks from coming back."""
+    if name == "builtin-dyn-autopkgupgrade-default":
+        for key in ("pkg_autoupdate_important", "enable_pkg_autoupdate_all", "upgrade_pkg_dsm_notification"):
+            if syno_get_key_value(SYNOINFO_CONF_PATH, key) != "no":
+                syno_set_key_value(SYNOINFO_CONF_PATH, key, "no")
+    elif name in ("builtin-synodbud-synodbud", "builtin-dyn-synodbud-default"):
+        run_cmd(["systemctl", "mask", "synodbud_autoupdate.service"])
+        run_cmd(["systemctl", "stop", "synodbud_autoupdate.service"])
+        run_cmd(["synodbud", "-p"])
 
 
-def handle_dyn_task_deletion(task_name):
-    if task_name == "builtin-dyn-autopkgupgrade-default":
-        log.debug(f"re-disabling dynamic task {task_name}")
-
-        param_val = syno_get_key_value(SYNOINFO_CONF_PATH, "pkg_autoupdate_important")
-        if not param_val or param_val != "no":
-            syno_set_key_value(SYNOINFO_CONF_PATH, "pkg_autoupdate_important", "no")
-
-        param_val = syno_get_key_value(SYNOINFO_CONF_PATH, "enable_pkg_autoupdate_all")
-        if not param_val or param_val != "no":
-            syno_set_key_value(SYNOINFO_CONF_PATH, "enable_pkg_autoupdate_all", "no")
-
-        param_val = syno_get_key_value(SYNOINFO_CONF_PATH, "upgrade_pkg_dsm_notification")
-        if not param_val or param_val != "no":
-            syno_set_key_value(SYNOINFO_CONF_PATH, "upgrade_pkg_dsm_notification", "no")
-
-    elif task_name in ("builtin-synodbud-synodbud", "builtin-dyn-synodbud-default"):
-        log.debug(f"re-disabling dynamic task {task_name}")
-
-        subprocess.run(["systemctl", "mask", "synodbud_autoupdate.service"])
-        subprocess.run(["systemctl", "stop", "synodbud_autoupdate.service"])
-        subprocess.run(["synodbud", "-p"])
-    else:
-        return
-
-
-def get_task_action_from_config(task_name):
-    if task_name in g_user_config:
-        return g_user_config[task_name]
-
-    log.warning(f"A new task {task_name} has been found, likely installed by "
-                 "a new package or a DSM update. Re-run the script install to "
-                 "tell what to do with this task. Skipping it for now")
-    return "skip"
-
-def apply_user_config_to_task_files():
-    files_tasks = {}
-
-    task_files_paths = enumerate_synocrond_task_files()
-    if task_files_paths:
-        files_tasks = load_synocrond_task_files(task_files_paths)
-
-    for filepath, tasks in files_tasks.items():
-        is_file_changed = False
-
-        for synotask in tasks:
-            task_name = synotask.task_name
-            chosen_opt = get_task_action_from_config(task_name)
-            cur_period = get_task_period(synotask.body)
-
-            if chosen_opt == "skip":
-                continue
-            elif chosen_opt == "delete":
-                is_file_changed = True
-                synotask.body["period"] = None
-            else:
-                assert(chosen_opt in ("hourly", "daily", "weekly", "monthly"))
-
-                if chosen_opt != cur_period:
-                    is_file_changed = True
-                    synotask.body["period"] = chosen_opt
-
-        if is_file_changed:
-            log.debug(f"applying user config to task files: going to change {filepath}")
-            new_tasks = [synotask for synotask in tasks
-                                  if synotask.body["period"] is not None]
-
-            shutil.copy(filepath, BACKUP_DIR)
-
-            if not new_tasks:
-                log.debug(f"deleting a task file {filepath} which has no tasks")
-                os.unlink(filepath)
-                continue
-            elif len(new_tasks) == 1:
-                json_body = new_tasks[0].body
-            else:
-                json_body = [item.body for item in new_tasks]
-
-            try:
-                with open(filepath, "w") as f:
-                    json.dump(json_body, f, indent=4)
-            except:
-                err("cannot save synocrond task changes to {filepath}")
-                pass
-
-def apply_user_config_to_synocrond_config():
-    synocrond_config = load_synocrond_config()
-    if not synocrond_config:
-        err("(run) cannot load synocrond.config")
-        return False
-
-    jobs = synocrond_config["jobs"]
-
-    is_changed = False
-    for task_name in jobs.copy().keys():
-        # DSM 7.2 task naming change
-        clean_task_name = task_name
-        if task_name.find("synocrond-job-") == 0:
-            clean_task_name = task_name.replace("synocrond-job-", "")
-
-        cur_period = get_task_period(jobs[task_name]["config"])
-        chosen_opt = get_task_action_from_config(clean_task_name)
-
-        if chosen_opt == "skip":
-            continue
-        elif chosen_opt == "delete":
-            is_changed = True
-            handle_dyn_task_deletion(clean_task_name)
-            del synocrond_config["jobs"][task_name]
-        else:
-            assert(chosen_opt in ("hourly", "daily", "weekly", "monthly"))
-
-            if chosen_opt != cur_period:
-                is_changed = True
-                synocrond_config["jobs"][task_name]["config"]["period"] = chosen_opt
-
-    if is_changed:
-        log.debug(f"going to change /usr/syno/etc/synocrond.config")
-
-        # 'systemctl reload synocrond' can fail
-        ret = subprocess.call(["systemctl", "stop", "synocrond"])
-        if ret:
-            err(f"stopping synocrond failed: {ret}")
-            return False
-
-        if not save_synocrond_config(synocrond_config):
-            err("saving synocrond.config changes failed")
-            subprocess.call(["systemctl", "start", "synocrond"])
-            return False
-
+def apply_config_to_task_files(actions: Dict[str, str]) -> None:
+    for path in enumerate_task_files():
         try:
-            shutil.rmtree("/run/synocrond")
-            os.unlink("/run/synocrond.st.config")
-            os.unlink("/run/synocrond.config")
-        except:
-            pass
+            tasks = load_task_file(path)
+        except Exception as e:
+            log.warning("skipping task file %s: %s", path, e)
+            continue
 
-        ret = subprocess.call(["systemctl", "start", "synocrond"])
-        if ret:
-            err(f"starting synocrond failed: {ret}")
-            return False
+        changed = False
+        remaining: List[SynocrondTask] = []
+        for t in tasks:
+            action = actions.get(t.name, "unchanged")
+            if action == "delete":
+                changed = True
+                continue  # drop this task; everything else is preserved as-is
+            if action in PERIOD_ACTIONS and t.body.get("period") != action:
+                t.body["period"] = action
+                changed = True
+            remaining.append(t)
 
-    return True
+        if not changed:
+            continue
+
+        backup_file(path)
+        try:
+            if not remaining:
+                log.info("removing task file %s (all its tasks deleted)", path)
+                os.unlink(path)
+                continue
+            payload = remaining[0].body if len(remaining) == 1 else [t.body for t in remaining]
+            with open(path, "w") as f:
+                json.dump(payload, f, indent=4)
+            log.info("updated task file %s", path)
+        except OSError as e:
+            log.error("cannot write %s: %s", path, e)
 
 
-def process_volume_conf():
-    spaces = []
+def apply_config_to_synocrond_config(actions: Dict[str, str]) -> bool:
+    cfg = load_synocrond_config()
+    if not cfg:
+        return False
+    jobs = cfg.get("jobs", {})
 
+    changed = False
+    for job_name in list(jobs.keys()):
+        name = clean_job_name(job_name)
+        action = actions.get(name, "unchanged")
+        cur_period = jobs[job_name].get("config", {}).get("period")
+        if action == "unchanged":
+            continue
+        if action == "delete":
+            _handle_dyn_task_deletion(name)
+            del jobs[job_name]
+            changed = True
+        elif action in PERIOD_ACTIONS and cur_period != action:
+            jobs[job_name]["config"]["period"] = action
+            changed = True
+
+    if not changed:
+        return True
+
+    log.info("updating %s", SYNOCROND_CONFIG_PATH)
+    if subprocess.call(["systemctl", "stop", "synocrond"]) != 0:
+        log.error("failed to stop synocrond")
+        return False
+
+    ok = True
+    try:
+        backup_file(SYNOCROND_CONFIG_PATH)
+        with open(SYNOCROND_CONFIG_PATH, "w") as f:
+            json.dump(cfg, f, indent=4)
+        # Drop the runtime cache so synocrond regenerates it from the new config.
+        for p in ("/run/synocrond", "/run/synocrond.st.config", "/run/synocrond.config"):
+            try:
+                if os.path.isdir(p):
+                    shutil.rmtree(p)
+                elif os.path.exists(p):
+                    os.unlink(p)
+            except OSError:
+                pass
+    except Exception as e:
+        log.error("failed to update synocrond.config: %s", e)
+        ok = False
+    finally:
+        # Always bring synocrond back up, even if the write failed.
+        if subprocess.call(["systemctl", "start", "synocrond"]) != 0:
+            log.error("failed to restart synocrond")
+            ok = False
+    return ok
+
+
+# --------------------------------------------------------------------------- #
+# 3) noatime + 4) synocached fixes
+# --------------------------------------------------------------------------- #
+
+def remount_root_noatime() -> None:
+    try:
+        out = subprocess.check_output(["mount"], universal_newlines=True)
+        for line in out.splitlines():
+            if " / " in line and "md0" in line and "noatime" in line:
+                return  # already noatime
+    except Exception:
+        pass
+    rc = subprocess.call(["mount", "-o", "noatime,remount", "/"],
+                         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if rc:
+        log.error("remounting / noatime failed; expect HDD wakeups from atime updates")
+    else:
+        log.info("remounted / as noatime")
+
+
+def apply_synocached_fix() -> None:
+    for fname in ("synocached.conf", "synocached.default.conf"):
+        path = os.path.join(SYNOCACHED_DIR, fname)
+        if not os.path.exists(path):
+            continue
+        try:
+            with open(path) as f:
+                data = f.read()
+            new_data = data.replace("timeout 3600", "timeout 900")
+            if new_data != data:
+                backup_file(path)
+                with open(path, "w") as f:
+                    f.write(new_data)
+                log.info("lowered synocached idle timeout in %s", path)
+        except OSError as e:
+            log.error("cannot update %s: %s", path, e)
+
+
+def _load_volume_names() -> Dict[str, str]:
+    names: Dict[str, str] = {}
     try:
         with open(SPACE_TABLE_PATH) as f:
             spaces = json.load(f)
-    except:
-        err(f"failed to load space table {SPACE_TABLE_PATH}")
-        return
-
-    volumes = {}    # fs_uuid -> id
-
-    for space in spaces:
-        for volume in space["volumes"]:
-            fs_uuid = volume["fs_uuid"]
-            vol_id  = volume["id"]
-            volumes[fs_uuid] = vol_id
-
-    volumes_atime_opt = {}  # fs_uuid -> atime_opt value
-
-    import configparser
-    volume_conf = None
-    try:
-        volume_conf = configparser.ConfigParser()
-        volume_conf.read(VOLUME_CONF_PATH)
-
-        for uuid in volume_conf.sections():
-            if "atime_opt" in volume_conf[uuid]:
-                volumes_atime_opt[uuid] = volume_conf[uuid]["atime_opt"]
-            else:
-                volumes_atime_opt[uuid] = ""
-    except:
-        err(f"failed to parse {VOLUME_CONF_PATH}")
-        return
-
-
-    bad_atime_opt_volumes = [uuid for uuid in volumes_atime_opt.keys()
-                                  if volumes_atime_opt[uuid] != "noatime"]
-
-    if not bad_atime_opt_volumes:
-        return # ok
-
-    bad_atime_opt_volnames = [volumes[uuid] if uuid in volumes else uuid
-                              for uuid in bad_atime_opt_volumes]
-
-    print("\nFound some volumes with 'Record File Access Time' enabled:",
-          ", ".join(bad_atime_opt_volnames))
-    print("It's better to disable this feature if you want to avoid random "
-          "HDD wakeups (note: it's different from files modification time)")
-
-    print("\nYou can change this setting yourself in DSM Storage Manager:")
-    print('1. For every volume you have, open its "..." menu and select Settings.')
-    print("2. On the volume Settings screen, set Record File Access Time to Never")
-
-    print("\nOr, alternatvely, you can let this tool to update the volume settings for you.")
-
-    answer = False
-    try:
-        resp = input("Would you like for the script to do it [y/N]? ")
-        if resp.lower() in ["y","yes"]:
-            answer = True
-    except:
+        for space in spaces:
+            for vol in space.get("volumes", []):
+                names[vol["fs_uuid"]] = vol["id"]
+    except Exception:
         pass
-
-    if answer:
-        # possible TBD: other *atime choices?
-        for uuid in bad_atime_opt_volumes:
-            volume_conf[uuid]["atime_opt"] = "noatime"
-
-        shutil.copy(VOLUME_CONF_PATH, BACKUP_DIR)
-
-        try:
-            with open(VOLUME_CONF_PATH, "w") as f:
-                volume_conf.write(f)
-        except:
-            err(f"failed to update {VOLUME_CONF_PATH}")
-            return
-
-        print("\nSuccessfully updated volume.conf to disable 'Record File Access Time'")
-        print("Don't forget to reboot your NAS to apply the new settings")
-    else:
-        print("\nSkipping changing any volume settings")
+    return names
 
 
-def create_sched_task_content(script_body):
-    assert(script_body)
-    compressed = lzma.compress(script_body, preset=9, format=lzma.FORMAT_ALONE)
-    compressed_base64 = base64.b64encode(compressed).decode()
-
-    cmd_lines = f'echo "{compressed_base64}" | base64 -d | xz -d --stdout > /tmp/hiber_fixer.py'
-    cmd_lines += '\n'
-    cmd_lines += "python3 /tmp/hiber_fixer.py --run"
-    #cmd_lines += '\n'
-    #cmd_lines += "rm /tmp/hiber_fixer.py"
-    return cmd_lines
-
-
-# returns it as bytes
-def prepare_own_body():
-    with open(__file__, "r") as f:
-        fcontent = f.read()
-
-    config_part = '\n'
-    for key, val in g_user_config.items():
-        config_part += f'    "{key}": "{val}",\n'
-
-    new_body = re.sub(r"#BEGIN_CONFIG_SECTION.+?    #END_CONFIG_SECTION",
-                      f"#BEGIN_CONFIG_SECTION{config_part}    #END_CONFIG_SECTION",
-                      fcontent, count=1, flags=re.DOTALL)
-    return bytes(new_body, "utf-8")
-
-
-def apply_misc_fixes():
-    # redis-related HDD wakeup in 1 hour after DSM WebUI usage
-    fpath1 = os.path.join(SYNOCACHED_CONF_DIRPATH, "synocached.conf")
-    fpath2 = os.path.join(SYNOCACHED_CONF_DIRPATH, "synocached.default.conf")
-    shutil.copy(fpath1, BACKUP_DIR)
-    shutil.copy(fpath2, BACKUP_DIR)
-
+def find_relatime_volumes() -> List[Tuple[str, str]]:
+    """Return [(uuid, display_name)] for volumes whose atime_opt != noatime."""
+    import configparser
+    names = _load_volume_names()
+    result: List[Tuple[str, str]] = []
     try:
-        with open(fpath1, "r") as f:
-            data = f.read()
-        new_data = data.replace("timeout 3600", "timeout 900")
-        if data != new_data:
-            with open(fpath1, "w") as f:
-                f.write(new_data)
-            log.debug(f"applied fixes to {fpath1}")
-
-        with open(fpath2, "r") as f:
-            data = f.read()
-        new_data = data.replace("timeout 3600", "timeout 900")
-        if data != new_data:
-            with open(fpath2, "w") as f:
-                f.write(new_data)
-            log.debug(f"applied fixes to {fpath2}")
+        conf = configparser.ConfigParser(interpolation=None)
+        conf.read(VOLUME_CONF_PATH)
+        for uuid in conf.sections():
+            if conf[uuid].get("atime_opt", "") != "noatime":
+                result.append((uuid, names.get(uuid, uuid)))
     except Exception as e:
-        err(f"cannot apply fixes to synocached: {e}")
-        return
+        log.error("failed to parse %s: %s", VOLUME_CONF_PATH, e)
+    return result
 
 
-def get_boot_state():
-    try:
-        ret = subprocess.run(["systemctl", "is-system-running"],
-                             capture_output=True,
-                             universal_newlines=True)
-        return ret.stdout.strip()
-    except:
-        return "unknown"
-
-BOOT_TIMEOUT = 180  # 3 min
-
-# returns False if timed out waiting
-def ensure_boot_complete():
-    state = get_boot_state()
-    if state in ("running", "degraded"):
+def set_volumes_noatime() -> bool:
+    import configparser
+    bad = find_relatime_volumes()
+    if not bad:
         return True
+    try:
+        conf = configparser.ConfigParser(interpolation=None)
+        conf.read(VOLUME_CONF_PATH)
+        for uuid, _name in bad:
+            conf[uuid]["atime_opt"] = "noatime"
+        backup_file(VOLUME_CONF_PATH)
+        with open(VOLUME_CONF_PATH, "w") as f:
+            conf.write(f, space_around_delimiters=False)
+        log.info("set noatime for volumes: %s", ", ".join(n for _u, n in bad))
+        log.warning("reboot required to apply the new volume atime settings")
+        return True
+    except Exception as e:
+        log.error("failed to update %s: %s", VOLUME_CONF_PATH, e)
+        return False
 
-    # systemd is still booting
-    pid = os.fork()
-    if pid == 0:
-        # in the child
-        start_time = time.time()
 
-        while True:
-            time.sleep(0.5)
-            state = get_boot_state()
-            cur_time = time.time()
+# --------------------------------------------------------------------------- #
+# Config file
+# --------------------------------------------------------------------------- #
 
-            if state in ("running", "degraded"):
-                log.debug("waited for boot to finish for {:.2f} sec".format(cur_time - start_time))
-                return True
+def config_path_for(script_path: str) -> str:
+    return os.path.join(os.path.dirname(os.path.abspath(script_path)), CONFIG_BASENAME)
 
-            if cur_time > start_time + BOOT_TIMEOUT:
-                return False
+
+def default_config() -> dict:
+    tasks = {}
+    discovered = discover_tasks()
+    for name in sorted(set(discovered) | set(DEFAULT_TASK_ACTIONS)):
+        tasks[name] = DEFAULT_TASK_ACTIONS.get(name, "unchanged")
+    return {
+        "_comment": "Actions: unchanged|hourly|daily|weekly|monthly|delete. Edit, then re-run --run.",
+        "fixes": dict(DEFAULT_FIXES),
+        "synocrond_tasks": tasks,
+    }
+
+
+def load_config(path: str) -> dict:
+    """Load config, filling in defaults and merging in any newly-discovered tasks."""
+    cfg = {}
+    if os.path.exists(path):
+        try:
+            with open(path) as f:
+                cfg = json.load(f)
+        except Exception as e:
+            log.error("cannot parse config %s: %s -- using defaults", path, e)
+    fixes = dict(DEFAULT_FIXES)
+    fixes.update(cfg.get("fixes", {}))
+    tasks = dict(cfg.get("synocrond_tasks", {}))
+
+    added = 0
+    for name in discover_tasks():
+        if name not in tasks:
+            tasks[name] = DEFAULT_TASK_ACTIONS.get(name, "unchanged")
+            added += 1
+    if added and os.path.exists(path):
+        log.info("config: %d newly-discovered task(s) added with default actions", added)
+
+    return {"_comment": cfg.get("_comment", default_config()["_comment"]),
+            "fixes": fixes, "synocrond_tasks": tasks}
+
+
+def save_config(path: str, cfg: dict) -> None:
+    with open(path, "w") as f:
+        json.dump(cfg, f, indent=4, sort_keys=False)
+
+
+# --------------------------------------------------------------------------- #
+# Task Scheduler integration
+# --------------------------------------------------------------------------- #
+
+def esynoscheduler() -> Optional[str]:
+    return which_first(ESYNOSCHEDULER_CANDIDATES)
+
+
+def scheduler_list_raw() -> str:
+    tool = esynoscheduler()
+    if not tool:
+        return ""
+    try:
+        return subprocess.check_output([tool, "--list"], stderr=subprocess.DEVNULL).decode("utf-8", "replace")
+    except Exception:
+        return ""
+
+
+def scheduler_tasks() -> List[dict]:
+    """Parse `esynoscheduler --list` output (log noise + a `jOut=[...]` JSON array)."""
+    raw = scheduler_list_raw()
+    j = raw.find("jOut=")
+    start = raw.find("[", j) if j != -1 else raw.find("[")
+    if start == -1:
+        return []
+    try:
+        val, _ = json.JSONDecoder().raw_decode(raw[start:])
+        return val if isinstance(val, list) else []
+    except Exception:
+        return []
+
+
+def scheduler_task_state(task_name: str) -> Optional[bool]:
+    """Return the enabled state of the boot task with this name, or None if absent."""
+    for t in scheduler_tasks():
+        if t.get("task_name") == task_name:
+            return bool(t.get("enable", False))
+    return None
+
+
+def create_boot_task(operation: str) -> bool:
+    tool = esynoscheduler()
+    if not tool:
+        log.error("esynoscheduler not found")
+        return False
+    args = [tool, "--create", f"task_name={TASK_NAME}", "event=bootup", "enable=true",
+            "operation_type=script", f"operation={operation}",
+            "description=HDD hibernation fixer (runs hiber_fixer.py at boot)",
+            r'owner={"0":"root"}']
+    try:
+        out = subprocess.check_output(args, stderr=subprocess.STDOUT).decode("utf-8", "replace")
+        return "save ok" in out
+    except Exception as e:
+        log.error("failed to create Task Scheduler task: %s", e)
+        return False
+
+
+def delete_boot_task() -> bool:
+    tool = esynoscheduler()
+    if not tool:
+        return False
+    try:
+        out = subprocess.check_output([tool, "--delete", f"task_name={TASK_NAME}"],
+                                      stderr=subprocess.STDOUT).decode("utf-8", "replace")
+        return "delete task ok" in out
+    except Exception:
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Boot readiness
+# --------------------------------------------------------------------------- #
+
+def system_running() -> bool:
+    try:
+        out = subprocess.run(["systemctl", "is-system-running"], capture_output=True,
+                             universal_newlines=True).stdout.strip()
+        return out in ("running", "degraded")
+    except Exception:
+        return True  # don't block if systemd query fails
+
+
+def wait_for_system(timeout: int = BOOT_WAIT_TIMEOUT) -> bool:
+    """Wait until systemd reports the boot has finished (running/degraded)."""
+    deadline = time.time() + timeout
+    while not system_running():
+        if time.time() >= deadline:
+            log.warning("system did not finish booting within %ds; continuing anyway", timeout)
+            return False
+        time.sleep(2)
+    return True
+
+
+def wait_for_daemons(timeout: int = BOOT_WAIT_TIMEOUT) -> bool:
+    """Wait until the in-memory patch targets (scemd, synostgd-disk) are running."""
+    deadline = time.time() + timeout
+    while True:
+        missing = [t.process_name for t in PATCH_TARGETS if not get_pid_by_name(t.process_name)]
+        if not missing:
+            return True
+        if time.time() >= deadline:
+            log.error("patch target daemon(s) not running within %ds: %s", timeout, ", ".join(missing))
+            return False
+        time.sleep(2)
+
+
+# --------------------------------------------------------------------------- #
+# Commands
+# --------------------------------------------------------------------------- #
+
+def cmd_run(config_path: str, wait: bool = True) -> int:
+    log.info("run: applying hibernation fixes")
+    cfg = load_config(config_path)
+    fixes = cfg["fixes"]
+    actions = cfg["synocrond_tasks"]
+
+    if wait:
+        wait_for_system()
+
+    ok = True
+    if fixes.get("remount_root_noatime", True):
+        remount_root_noatime()
+    if fixes.get("nvme_in_memory_patch", True):
+        if wait:
+            wait_for_daemons()   # gate only the in-memory patch on the daemons being up
+        ok = do_in_memory_fixes() and ok
+    apply_config_to_task_files(actions)
+    ok = apply_config_to_synocrond_config(actions) and ok
+    if fixes.get("synocached_timeout_900", True):
+        apply_synocached_fix()
+
+    relatime = find_relatime_volumes()
+    if relatime:
+        if fixes.get("set_volumes_noatime", False):
+            set_volumes_noatime()
+        else:
+            log.warning("volumes still using relatime (set fixes.set_volumes_noatime=true to fix): %s",
+                        ", ".join(n for _u, n in relatime))
+
+    log.info("run: done (%s)", "ok" if ok else "with errors")
+    return 0 if ok else 1
+
+
+def cmd_install(script_path: str, install_dir: str) -> int:
+    install_dir = os.path.abspath(install_dir)
+    os.makedirs(install_dir, exist_ok=True)
+    installed_script = os.path.join(install_dir, "hiber_fixer.py")
+
+    src = os.path.abspath(script_path)
+    if src != installed_script:
+        shutil.copy2(src, installed_script)
+        print(f"Installed script to {installed_script}")
     else:
-        # in the parent
-        sys.exit(0)
+        print(f"Running from install location {installed_script}")
 
-
-def run():
-    log.debug("run() triggered for the scheduled task")
-    if not ensure_boot_complete():
-        log.error("timed out while waiting for boot to complete!")
-        return -1
-    remount_root_norelatime()
-    do_in_memory_fixes()
-    apply_user_config_to_task_files()
-    ret = apply_user_config_to_synocrond_config()
-    return 0 if ret else -1
-
-def install():
-    global _print_to_console
-    _print_to_console = True
-
-    if not generate_user_config():
-        return -1
-
-    process_volume_conf()
-    apply_misc_fixes()
-
-    script_body = prepare_own_body()
-
-    operation_cmds = create_sched_task_content(script_body)
-
-    remove_esynoscheduler_task(TASK_SCHEDULER_TASKNAME)
-
-    ret = add_esynoscheduler_task(TASK_SCHEDULER_TASKNAME, "bootup",
-                                  "HDD hibernation fixer task",
-                                  operation_cmds)
-    if not ret:
-        print("Failed to create the Task Scheduler task, aborting")
-        return -1
-
-    print("Applying changes...")
-    ret = run()
-    print("\nInstallation finished successfully. You can delete this file "
-          f"({os.path.basename(__file__)}) now, it's no longer needed.")
-    return ret
-
-def uninstall():
-    ret = remove_esynoscheduler_task(TASK_SCHEDULER_TASKNAME)
-    if ret:
-        print("Successfully deleted the hibernation fixer scheduled task. "
-              "It's recommended to reboot your NAS")
-        return 0
+    config_path = os.path.join(install_dir, CONFIG_BASENAME)
+    if not os.path.exists(config_path):
+        save_config(config_path, default_config())
+        print(f"Wrote default config to {config_path}")
+        print("  Review/edit it to choose what to do with each synocrond task, then re-run --run if needed.")
     else:
-        print("ERROR: failed to delete the hibernation fixer scheduled task")
-        return -1
+        # merge in any new tasks
+        save_config(config_path, load_config(config_path))
+        print(f"Kept existing config {config_path}")
+
+    operation = f"{PYTHON} {installed_script} --run"
+    delete_boot_task()
+    if not create_boot_task(operation):
+        print("ERROR: failed to create the boot-up Task Scheduler task")
+        return 1
+    print(f'Created boot-up task "{TASK_NAME}" -> {operation}')
+
+    print("\nApplying fixes now...")
+    rc = cmd_run(config_path, wait=False)
+    print("\nInstallation complete. The fixes will re-apply automatically on every boot.")
+    print(f"You can delete the copy you ran --install from; the active copy lives in {install_dir}.")
+    return rc
 
 
-def usage():
-    print(f"USAGE: {sys.argv[0]} [--install | --uninstall | --run]\n")
-    print(f"   --install\tInstall hibernation fixer as a (on-boot) scheduled task")
-    print(f"   --uninstall\tRemove the hibernation fixer scheduled task")
-    print(f"   --run\tApply all fixes (normally used by the task)")
+def cmd_uninstall(script_path: str, purge: bool) -> int:
+    if delete_boot_task():
+        print(f'Removed the "{TASK_NAME}" boot task.')
+    else:
+        print(f'Could not remove the "{TASK_NAME}" boot task (maybe already gone).')
+    print("The in-memory NVMe patch is not persistent; reboot to fully revert it.")
+    if purge:
+        install_dir = os.path.dirname(os.path.abspath(script_path))
+        print(f"--purge: leaving {install_dir} in place; delete it manually if you want.")
+        print(f"Backups of modified config files are in {BACKUP_DIR}.")
+    return 0
 
 
-def main():
-    if len(sys.argv) != 2:
-        usage()
-        return -1
+def cmd_status(config_path: str) -> int:
+    print(f"== HDD Hibernation Fixer status ==\n")
 
+    state = scheduler_task_state(TASK_NAME)
+    if state is None:
+        print(f'Boot task "{TASK_NAME}": NOT INSTALLED')
+    else:
+        print(f'Boot task "{TASK_NAME}": {"ENABLED" if state else "DISABLED (re-enable it or re-run --install)"}')
+
+    print("\nIn-memory NVMe patch (current process state):")
+    try:
+        libc = _Libc()
+    except Exception as e:
+        libc = None
+        print(f"  (cannot read process memory: {e})")
+    if libc:
+        for target in PATCH_TARGETS:
+            _status_report_target(libc, target)
+
+    print("\nnoatime:")
+    try:
+        mounts = subprocess.check_output(["mount"], universal_newlines=True)
+        root_noatime = any(" / " in l and "md0" in l and "noatime" in l for l in mounts.splitlines())
+        print(f"  root (/) noatime: {'yes' if root_noatime else 'NO'}")
+    except Exception:
+        print("  root (/) noatime: unknown")
+    relatime = find_relatime_volumes()
+    print(f"  volumes on relatime: {', '.join(n for _u, n in relatime) if relatime else 'none'}")
+
+    print("\nsynocached idle timeout:")
+    conf = os.path.join(SYNOCACHED_DIR, "synocached.conf")
+    if os.path.exists(conf):
+        try:
+            val = "?"
+            with open(conf) as f:
+                for line in f:
+                    if line.startswith("timeout"):
+                        val = line.split()[1]
+            print(f"  {conf}: timeout {val}")
+        except Exception:
+            print(f"  {conf}: unreadable")
+
+    if os.path.exists(config_path):
+        cfg = load_config(config_path)
+        acts = cfg["synocrond_tasks"]
+        changed = {k: v for k, v in acts.items() if v != "unchanged"}
+        print(f"\nConfig: {config_path}")
+        print(f"  fixes: {cfg['fixes']}")
+        print(f"  synocrond tasks: {len(acts)} known, {len(changed)} set to change")
+    else:
+        print(f"\nConfig: not found at {config_path}")
+    return 0
+
+
+def _status_report_target(libc: _Libc, target: PatchTarget) -> None:
+    pid = get_pid_by_name(target.process_name)
+    if not pid:
+        print(f"  {target.process_name}: not running")
+        return
+    base = get_module_base(pid, os.path.basename(target.binary_path))
+    if base is None:
+        print(f"  {target.process_name}: module base not found")
+        return
+    try:
+        segs = parse_elf_load_segments(open(target.binary_path, "rb").read())
+    except Exception as e:
+        print(f"  {target.process_name}: cannot parse binary ({e})")
+        return
+    for variant in target.variants:
+        changes = compute_changelist(target.binary_path, variant)
+        if not changes:
+            continue
+        states = []
+        for ch in changes:
+            vaddr = file_offset_to_vaddr(segs, ch.file_offset)
+            cur = libc.read_mem(pid, base + vaddr, len(ch.orig)) if vaddr is not None else None
+            if cur == ch.new:
+                states.append("patched")
+            elif cur == ch.orig:
+                states.append("original")
+            else:
+                states.append("unknown")
+        verdict = "PATCHED" if all(s == "patched" for s in states) else \
+                  "not patched" if all(s == "original" for s in states) else "partial/unknown"
+        print(f"  {target.process_name}: {verdict} (matched {variant.name})")
+        return
+    print(f"  {target.process_name}: NO PATTERN MATCH -- binary changed; run --diagnose")
+
+
+def cmd_diagnose() -> int:
+    """Report pattern matches against the on-disk binaries and dump candidate sites
+    if nothing matches (useful to regenerate patterns after a DSM update)."""
+    print("== diagnose ==")
+    for target in PATCH_TARGETS:
+        print(f"\n{target.binary_path} (process {target.process_name}):")
+        if not os.path.exists(target.binary_path):
+            print("  binary not found")
+            continue
+        data = open(target.binary_path, "rb").read()
+        matched = False
+        for variant in target.variants:
+            rx = _compile_search(variant.search)
+            hits = list(rx.finditer(data))
+            print(f"  variant '{variant.name}': {len(hits)} match(es)"
+                  + (f" at {hits[0].start():#x}" if hits else ""))
+            matched = matched or bool(hits)
+        if not matched:
+            print("  no variant matched -- scanning for candidate 'mov edi,7; call' sites:")
+            for off in [m.start() for m in re.finditer(re.escape(b"\xBF\x07\x00\x00\x00\xE8"), data)]:
+                ctx = data[max(0, off - 24):off + 16]
+                if b"\xBF\x01" in ctx or b"\xBF\x03" in ctx:
+                    lo = max(0, off - 24)
+                    print(f"    off {off:#x}: ...{data[lo:off + 32].hex()}...")
+            print("  Send this output to regenerate the patterns for your DSM build.")
+    return 0
+
+
+def cmd_configure(config_path: str) -> int:
+    """Interactive editor for the synocrond task actions."""
+    cfg = load_config(config_path) if os.path.exists(config_path) else default_config()
+    discovered = discover_tasks()
+    actions = cfg["synocrond_tasks"]
+
+    names = sorted(set(discovered) | set(actions))
+    print("Choose an action per task. Enter = keep current default.")
+    print("Options: (u)nchanged (h)ourly (d)aily (w)eekly (m)onthly (x)delete\n")
+    letter = {"u": "unchanged", "h": "hourly", "d": "daily", "w": "weekly", "m": "monthly", "x": "delete"}
+    try:
+        for i, name in enumerate(names, 1):
+            cur_period, descr = discovered.get(name, ("(not present)", describe_task(name)))
+            default = actions.get(name, "unchanged")
+            print(f"[{i}/{len(names)}] {name}")
+            if descr:
+                print(f"     {descr}")
+            print(f"     current interval: {cur_period}   default action: {default}")
+            while True:
+                ch = input("     action [u/h/d/w/m/x]: ").strip().lower()
+                if not ch:
+                    break
+                if ch[0] in letter:
+                    actions[name] = letter[ch[0]]
+                    break
+                print("     invalid, try again")
+            print()
+    except (KeyboardInterrupt, EOFError):
+        print("\nCancelled; nothing saved.")
+        return 1
+
+    cfg["synocrond_tasks"] = actions
+    save_config(config_path, cfg)
+    print(f"Saved {config_path}")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+
+def setup_logging(verbose: bool) -> None:
+    log.setLevel(logging.DEBUG)
+    try:
+        fh = logging.FileHandler(LOG_PATH)
+        fh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s\t%(message)s"))
+        log.addHandler(fh)
+    except Exception:
+        pass
+    sh = logging.StreamHandler(sys.stderr)
+    sh.setLevel(logging.DEBUG if verbose else logging.INFO)
+    sh.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+    log.addHandler(sh)
+
+
+def preflight(require_root: bool = True) -> Optional[str]:
     if platform.machine() != "x86_64":
-        print("Only x86-based NAS models are supported")
-        return -1
-
-    majorver = syno_get_key_value("/etc.defaults/VERSION", "majorversion")
-    if not majorver or majorver != '7':
-        print("Please run this script on DSM 7")
-        return -1
-
-    if os.geteuid() != 0:
-        print("Please run this script with root privileges (using 'sudo')")
-        return -1
-
-    log.basicConfig(filename=LOGFILE, level=LOGLEVEL,
-                    format="%(asctime)s %(levelname)s\t%(message)s")
-
-    opt = sys.argv[1]
-    if opt == "--install":
-        return install()
-    elif opt == "--uninstall":
-        return uninstall()
-    elif opt == "--run":
-        return run()
-    else:
-        usage()
-
-    return -1
+        return "Only x86_64-based NAS models are supported."
+    major = syno_get_key_value(VERSION_PATH, "majorversion")
+    if major and major != "7":
+        return f"This script targets DSM 7 (found major version {major})."
+    if require_root and hasattr(os, "geteuid") and os.geteuid() != 0:
+        return "Please run with root privileges (sudo)."
+    return None
 
 
-exit(main())
+def main(argv: List[str]) -> int:
+    parser = argparse.ArgumentParser(description="Synology DSM HDD hibernation fixer")
+    g = parser.add_mutually_exclusive_group(required=True)
+    g.add_argument("--install", action="store_true", help="install the boot task and apply fixes")
+    g.add_argument("--uninstall", action="store_true", help="remove the boot task")
+    g.add_argument("--run", action="store_true", help="apply all fixes now")
+    g.add_argument("--status", action="store_true", help="show current state")
+    g.add_argument("--diagnose", action="store_true", help="dump patch-site info")
+    g.add_argument("--configure", action="store_true", help="interactively edit the config")
+    parser.add_argument("--install-dir", default=DEFAULT_INSTALL_DIR, help=f"install location (default {DEFAULT_INSTALL_DIR})")
+    parser.add_argument("--config", default=None, help="path to config file (default: next to the script)")
+    parser.add_argument("--purge", action="store_true", help="with --uninstall: also report leftover files/backups")
+    parser.add_argument("-v", "--verbose", action="store_true", help="verbose console output")
+    args = parser.parse_args(argv)
+
+    setup_logging(args.verbose)
+
+    need_root = not (args.status or args.diagnose)
+    err = preflight(require_root=need_root)
+    if err:
+        print(f"ERROR: {err}")
+        return 1
+
+    script_path = os.path.abspath(sys.argv[0])
+    config_path = args.config or config_path_for(script_path)
+
+    if args.install:
+        return cmd_install(script_path, args.install_dir)
+    if args.uninstall:
+        return cmd_uninstall(script_path, purge=args.purge)
+    if args.run:
+        return cmd_run(config_path)
+    if args.status:
+        return cmd_status(config_path)
+    if args.diagnose:
+        return cmd_diagnose()
+    if args.configure:
+        return cmd_configure(config_path)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
…n the task

- The boot task now runs `python3 <install-dir>/hiber_fixer.py --run` instead of an xz+base64 copy of the whole script embedded in the Task Scheduler task. Installs to a data volume (default /volume1/hiber_fixer) so both task and script survive DSM upgrades.
- Task actions moved to an external declarative JSON config beside the script (no more choices baked into the source). New tasks from future DSM/package updates are merged in.
- In-memory NVMe patch: data-driven patterns, correct ELF file-offset->vaddr mapping via program headers, and loud failure (+ --diagnose) if a future DSM build no longer matches. Patterns verified against DSM 7.3.2 (byte-identical to 7.2). Semantics confirmed with Ghidra: SYNODiskPortEnum port type 7 = NVMe; the patch removes NVMe from the disk-idle set.
- New commands --status / --diagnose / --configure; argparse, real logging, dataclasses.
- Kept synocrond tuning, noatime, and synocached fixes; hardened config edits (explicit task deletion, always-restart synocrond, path-namespaced backups, ptrace PEEK errno check, package-task naming, decoupled the non-patch fixes from patch-daemon readiness).